### PR TITLE
Migrate to null safety + PC 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## 1.0.0
-
-- Null safety migration
 
 ## 0.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 0.1.4
+
+- Upgraded dependency to Pointy Castle's new 2.0.0 release.
+
 ## 0.1.3
 
 - Added support for P-256K curve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0
+
+- Null safety migration
 
 ## 0.1.3
 

--- a/example/encryption_example.dart
+++ b/example/encryption_example.dart
@@ -7,7 +7,7 @@ void main() {
 
   // Use the public key to create an encrypter with the AES/GCM algorithm
   var encrypter =
-      keyPair.publicKey!.createEncrypter(algorithms.encryption.aes.gcm);
+      keyPair.publicKey.createEncrypter(algorithms.encryption.aes.gcm);
 
   // Encrypt the content with an additional authentication data for integrity
   // protection
@@ -22,7 +22,7 @@ void main() {
 
   // Use the private key to create the decrypter
   var decrypter =
-      keyPair.privateKey!.createEncrypter(algorithms.encryption.aes.gcm);
+      keyPair.privateKey.createEncrypter(algorithms.encryption.aes.gcm);
 
   // Decrypt and verify authentication tag
   var decrypted = decrypter.decrypt(v);

--- a/example/encryption_example.dart
+++ b/example/encryption_example.dart
@@ -7,7 +7,7 @@ void main() {
 
   // Use the public key to create an encrypter with the AES/GCM algorithm
   var encrypter =
-      keyPair.publicKey.createEncrypter(algorithms.encryption.aes.gcm);
+      keyPair.publicKey!.createEncrypter(algorithms.encryption.aes.gcm);
 
   // Encrypt the content with an additional authentication data for integrity
   // protection
@@ -22,7 +22,7 @@ void main() {
 
   // Use the private key to create the decrypter
   var decrypter =
-      keyPair.privateKey.createEncrypter(algorithms.encryption.aes.gcm);
+      keyPair.privateKey!.createEncrypter(algorithms.encryption.aes.gcm);
 
   // Decrypt and verify authentication tag
   var decrypted = decrypter.decrypt(v);

--- a/example/signing_example.dart
+++ b/example/signing_example.dart
@@ -12,7 +12,7 @@ void main() {
   // A key pair has a private and public key, possibly one of them is null, if
   // required info was not available when construction
   // The private key can be used for signing
-  var privateKey = keyPair.privateKey!;
+  var privateKey = keyPair.privateKey;
 
   // Create a signer for the key using the HMAC/SHA-256 algorithm
   var signer = privateKey.createSigner(algorithms.signing.hmac.sha256);
@@ -25,7 +25,7 @@ void main() {
   print('Signature: ${signature.data}');
 
   // The public key can be used for verifying the signature
-  var publicKey = keyPair.publicKey!;
+  var publicKey = keyPair.publicKey;
 
   // Create a verifier for the key using the specified algorithm
   var verifier = publicKey.createVerifier(algorithms.signing.hmac.sha256);

--- a/example/signing_example.dart
+++ b/example/signing_example.dart
@@ -12,7 +12,7 @@ void main() {
   // A key pair has a private and public key, possibly one of them is null, if
   // required info was not available when construction
   // The private key can be used for signing
-  var privateKey = keyPair.privateKey;
+  var privateKey = keyPair.privateKey!;
 
   // Create a signer for the key using the HMAC/SHA-256 algorithm
   var signer = privateKey.createSigner(algorithms.signing.hmac.sha256);
@@ -25,7 +25,7 @@ void main() {
   print('Signature: ${signature.data}');
 
   // The public key can be used for verifying the signature
-  var publicKey = keyPair.publicKey;
+  var publicKey = keyPair.publicKey!;
 
   // Create a verifier for the key using the specified algorithm
   var verifier = publicKey.createVerifier(algorithms.signing.hmac.sha256);

--- a/lib/crypto_keys.dart
+++ b/lib/crypto_keys.dart
@@ -1,21 +1,27 @@
 library crypto_keys;
 
-import 'dart:convert';
-import 'dart:typed_data';
+import 'package:meta/meta.dart';
 
-import 'package:pointycastle/export.dart' as pc hide GCMBlockCipher;
-
-import 'src/algorithms.dart';
 import 'src/impl.dart';
+import 'dart:typed_data';
+import 'package:pointycastle/export.dart' as pc;
 import 'src/pointycastle_ext.dart' as pc;
+import 'dart:convert';
+import 'src/algorithms.dart';
 
 export 'src/algorithms.dart'
     show algorithms, curves, Algorithms, AlgorithmIdentifier, Identifier;
 
-part 'src/asymmetric_operator.dart';
-part 'src/ec_keys.dart';
 part 'src/keys.dart';
-part 'src/operator.dart';
+
 part 'src/rsa_keys.dart';
+
+part 'src/ec_keys.dart';
+
 part 'src/symmetric_keys.dart';
+
+part 'src/operator.dart';
+
 part 'src/symmetric_operator.dart';
+
+part 'src/asymmetric_operator.dart';

--- a/lib/crypto_keys.dart
+++ b/lib/crypto_keys.dart
@@ -1,27 +1,21 @@
 library crypto_keys;
 
-import 'package:meta/meta.dart';
-
-import 'src/impl.dart';
-import 'dart:typed_data';
-import 'package:pointycastle/export.dart' as pc;
-import 'src/pointycastle_ext.dart' as pc;
 import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:pointycastle/export.dart' as pc hide GCMBlockCipher;
+
 import 'src/algorithms.dart';
+import 'src/impl.dart';
+import 'src/pointycastle_ext.dart' as pc;
 
 export 'src/algorithms.dart'
     show algorithms, curves, Algorithms, AlgorithmIdentifier, Identifier;
 
-part 'src/keys.dart';
-
-part 'src/rsa_keys.dart';
-
-part 'src/ec_keys.dart';
-
-part 'src/symmetric_keys.dart';
-
-part 'src/operator.dart';
-
-part 'src/symmetric_operator.dart';
-
 part 'src/asymmetric_operator.dart';
+part 'src/ec_keys.dart';
+part 'src/keys.dart';
+part 'src/operator.dart';
+part 'src/rsa_keys.dart';
+part 'src/symmetric_keys.dart';
+part 'src/symmetric_operator.dart';

--- a/lib/crypto_keys.dart
+++ b/lib/crypto_keys.dart
@@ -1,27 +1,21 @@
 library crypto_keys;
 
-import 'package:meta/meta.dart';
-
-import 'src/impl.dart';
-import 'dart:typed_data';
-import 'package:pointycastle/export.dart' as pc;
-import 'src/pointycastle_ext.dart' as pc;
 import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:pointycastle/export.dart' as pc;
+
 import 'src/algorithms.dart';
+import 'src/impl.dart';
+import 'src/pointycastle_ext.dart' as pc;
 
 export 'src/algorithms.dart'
     show algorithms, curves, Algorithms, AlgorithmIdentifier, Identifier;
 
-part 'src/keys.dart';
-
-part 'src/rsa_keys.dart';
-
-part 'src/ec_keys.dart';
-
-part 'src/symmetric_keys.dart';
-
-part 'src/operator.dart';
-
-part 'src/symmetric_operator.dart';
-
 part 'src/asymmetric_operator.dart';
+part 'src/ec_keys.dart';
+part 'src/keys.dart';
+part 'src/operator.dart';
+part 'src/rsa_keys.dart';
+part 'src/symmetric_keys.dart';
+part 'src/symmetric_operator.dart';

--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -3,7 +3,7 @@ library crypto_keys.algorithms;
 import 'package:crypto_keys/src/pointycastle_oaep256.dart';
 import 'package:pointycastle/export.dart' as pc;
 import 'dart:math' show Random;
-import 'pointycastle_ext.dart' as pc;
+import 'pointycastle_ext.dart' as pce;
 import 'dart:typed_data';
 
 /// Contains the identifiers for supported algorithms
@@ -53,10 +53,10 @@ class AesEncAlgorithms extends Identifier {
 
   /// AES GCM
   final gcm = AlgorithmIdentifier._(
-      'enc/AES/GCM', () => pc.GCMBlockCipher(pc.AESFastEngine()));
+      'enc/AES/GCM', () => pce.GCMBlockCipher(pc.AESFastEngine()));
 
   /// AES Key Wrap with default initial value
-  final keyWrap = AlgorithmIdentifier._('enc/AES/KW', () => pc.AESKeyWrap());
+  final keyWrap = AlgorithmIdentifier._('enc/AES/KW', () => pce.AESKeyWrap());
 
   AesEncAlgorithms() : super._('enc/AES');
 }
@@ -65,19 +65,19 @@ class AesWithHmacEncAlgorithms extends Identifier {
   /// AES_128_CBC_HMAC_SHA_256 authenticated encryption algorithm
   final sha256 = AlgorithmIdentifier._(
       'enc/AES/CBC/PKCS7+HMAC/SHA-256',
-      () => pc.AesCbcAuthenticatedCipherWithHash(
+      () => pce.AesCbcAuthenticatedCipherWithHash(
           algorithms.signing.hmac.sha256.createAlgorithm()));
 
   /// AES_192_CBC_HMAC_SHA_384 authenticated encryption algorithm
   final sha384 = AlgorithmIdentifier._(
       'enc/AES/CBC/PKCS7+HMAC/SHA-384',
-      () => pc.AesCbcAuthenticatedCipherWithHash(
+      () => pce.AesCbcAuthenticatedCipherWithHash(
           algorithms.signing.hmac.sha384.createAlgorithm()));
 
   /// AES_256_CBC_HMAC_SHA_512 authenticated encryption algorithm
   final sha512 = AlgorithmIdentifier._(
       'enc/AES/CBC/PKCS7+HMAC/SHA-512',
-      () => pc.AesCbcAuthenticatedCipherWithHash(
+      () => pce.AesCbcAuthenticatedCipherWithHash(
           algorithms.signing.hmac.sha512.createAlgorithm()));
 
   AesWithHmacEncAlgorithms() : super._('enc/AES/CBC/PKCS7+HMAC');

--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -1,7 +1,7 @@
 library crypto_keys.algorithms;
 
 import 'package:crypto_keys/src/pointycastle_oaep256.dart';
-import 'package:pointycastle/export.dart' as pc hide GCMBlockCipher;
+import 'package:pointycastle/export.dart' as pc;
 import 'dart:math' show Random;
 import 'pointycastle_ext.dart' as pc;
 import 'dart:typed_data';
@@ -196,7 +196,7 @@ class AlgorithmIdentifier<T extends pc.Algorithm> extends Identifier {
 
   AlgorithmIdentifier._(String name, this.factory) : super._(name);
 
-  static final _jwaAlgorithms = <String, AlgorithmIdentifier?>{
+  static final _jwaAlgorithms = <String, AlgorithmIdentifier>{
     // Algorithms for JWS
 
     /// HMAC using SHA-256
@@ -310,7 +310,7 @@ class AlgorithmIdentifier<T extends pc.Algorithm> extends Identifier {
     'A256GCM': algorithms.encryption.aes.gcm,
   };
 
-  static AlgorithmIdentifier? getByJwaName(String alg) {
+  static AlgorithmIdentifier getByJwaName(String alg) {
     var i = _jwaAlgorithms[alg];
     if (i == null && alg != 'none') {
       if (_jwaAlgorithms.containsKey(alg)) {

--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -1,7 +1,7 @@
 library crypto_keys.algorithms;
 
 import 'package:crypto_keys/src/pointycastle_oaep256.dart';
-import 'package:pointycastle/export.dart' as pc;
+import 'package:pointycastle/export.dart' as pc hide GCMBlockCipher;
 import 'dart:math' show Random;
 import 'pointycastle_ext.dart' as pc;
 import 'dart:typed_data';
@@ -196,7 +196,7 @@ class AlgorithmIdentifier<T extends pc.Algorithm> extends Identifier {
 
   AlgorithmIdentifier._(String name, this.factory) : super._(name);
 
-  static final _jwaAlgorithms = <String, AlgorithmIdentifier>{
+  static final _jwaAlgorithms = <String, AlgorithmIdentifier?>{
     // Algorithms for JWS
 
     /// HMAC using SHA-256
@@ -310,7 +310,7 @@ class AlgorithmIdentifier<T extends pc.Algorithm> extends Identifier {
     'A256GCM': algorithms.encryption.aes.gcm,
   };
 
-  static AlgorithmIdentifier getByJwaName(String alg) {
+  static AlgorithmIdentifier? getByJwaName(String alg) {
     var i = _jwaAlgorithms[alg];
     if (i == null && alg != 'none') {
       if (_jwaAlgorithms.containsKey(alg)) {

--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -196,7 +196,7 @@ class AlgorithmIdentifier<T extends pc.Algorithm> extends Identifier {
 
   AlgorithmIdentifier._(String name, this.factory) : super._(name);
 
-  static final _jwaAlgorithms = <String, AlgorithmIdentifier>{
+  static final _jwaAlgorithms = <String, AlgorithmIdentifier?>{
     // Algorithms for JWS
 
     /// HMAC using SHA-256
@@ -310,7 +310,7 @@ class AlgorithmIdentifier<T extends pc.Algorithm> extends Identifier {
     'A256GCM': algorithms.encryption.aes.gcm,
   };
 
-  static AlgorithmIdentifier getByJwaName(String alg) {
+  static AlgorithmIdentifier? getByJwaName(String alg) {
     var i = _jwaAlgorithms[alg];
     if (i == null && alg != 'none') {
       if (_jwaAlgorithms.containsKey(alg)) {

--- a/lib/src/asymmetric_operator.dart
+++ b/lib/src/asymmetric_operator.dart
@@ -138,8 +138,11 @@ class _AsymmetricEncrypter extends Encrypter<Key> with _AsymmetricOperator {
 
   @override
   Uint8List decrypt(EncryptionResult input) {
-    _algorithm.init(false,
-        pc.ParametersWithRandom(keyParameter, pc.SecureRandom('Fortuna')));
+    _algorithm.init(
+        false,
+        pc.ParametersWithRandom(keyParameter, pc.SecureRandom('Fortuna')
+            // ..seed(pc.KeyParameter(Uint8List(32)))
+            ));
 
     return _algorithm.process(input.data);
   }

--- a/lib/src/asymmetric_operator.dart
+++ b/lib/src/asymmetric_operator.dart
@@ -17,22 +17,22 @@ abstract class _AsymmetricOperator<T extends Key> implements Operator<T> {
   }
 
   pc.ECDomainParameters get ecDomainParameters =>
-      createCurveParameters((key as EcKey).curve);
+      createCurveParameters((key as EcKey).curve!);
 
   pc.AsymmetricKeyParameter get keyParameter {
     if (key is RsaPrivateKey) {
       var k = key as RsaPrivateKey;
       return pc.PrivateKeyParameter<pc.RSAPrivateKey>(pc.RSAPrivateKey(
-          k.modulus,
-          k.privateExponent,
+          k.modulus!,
+          k.privateExponent!,
           k.firstPrimeFactor,
           k.secondPrimeFactor));
     }
     if (key is RsaPublicKey) {
       var k = key as RsaPublicKey;
       return pc.PublicKeyParameter<pc.RSAPublicKey>(pc.RSAPublicKey(
-        k.modulus,
-        k.exponent,
+        k.modulus!,
+        k.exponent!,
       ));
     }
     var d = ecDomainParameters;
@@ -47,8 +47,8 @@ abstract class _AsymmetricOperator<T extends Key> implements Operator<T> {
     if (key is EcPublicKey) {
       var k = key as EcPublicKey;
 
-      return pc.PublicKeyParameter<pc.ECPublicKey>(
-          pc.ECPublicKey(d.curve.createPoint(k.xCoordinate, k.yCoordinate), d));
+      return pc.PublicKeyParameter<pc.ECPublicKey>(pc.ECPublicKey(
+          d.curve.createPoint(k.xCoordinate!, k.yCoordinate!), d));
     }
     throw StateError('Unexpected key type ${key}');
   }
@@ -60,7 +60,7 @@ class _AsymmetricSigner extends Signer<PrivateKey>
       : super._(algorithm, key);
 
   @override
-  pc.Signer get _algorithm => super._algorithm;
+  pc.Signer get _algorithm => super._algorithm as pc.Signer;
 
   @override
   Signature sign(List<int> data) {
@@ -80,7 +80,7 @@ class _AsymmetricSigner extends Signer<PrivateKey>
         curves.p256k: 32,
         curves.p384: 48,
         curves.p521: 66
-      }[(key as EcKey).curve];
+      }[(key as EcKey).curve!]!;
       var bytes = Uint8List(length * 2);
       bytes.setRange(
           0, length, _bigIntToBytes(sig.r, length).toList().reversed);
@@ -99,12 +99,13 @@ class _AsymmetricVerifier extends Verifier<PublicKey>
       : super._(algorithm, key);
 
   @override
-  pc.Signer get _algorithm => super._algorithm;
+  pc.Signer get _algorithm => super._algorithm as pc.Signer;
 
   @override
   bool verify(Uint8List data, Signature signature) {
     if (key is RsaKey) {
-      _algorithm.init(false, pc.ParametersWithRandom(keyParameter, null));
+      _algorithm.init(false,
+          pc.ParametersWithRandom(keyParameter, pc.SecureRandom('Fortuna')));
       try {
         return _algorithm.verifySignature(
             data, pc.RSASignature(signature.data));
@@ -132,26 +133,25 @@ class _AsymmetricEncrypter extends Encrypter<Key> with _AsymmetricOperator {
   _AsymmetricEncrypter(Identifier algorithm, Key key) : super._(algorithm, key);
 
   @override
-  pc.AsymmetricBlockCipher get _algorithm => super._algorithm;
+  pc.AsymmetricBlockCipher get _algorithm =>
+      super._algorithm as pc.AsymmetricBlockCipher;
 
   @override
   Uint8List decrypt(EncryptionResult input) {
-    _algorithm.init(
-        false,
-        pc.ParametersWithRandom(keyParameter, null //pc.SecureRandom('Fortuna')
-            //..seed(pc.KeyParameter(Uint8List(32)))
-            ));
+    _algorithm.init(false,
+        pc.ParametersWithRandom(keyParameter, pc.SecureRandom('Fortuna')));
 
     return _algorithm.process(input.data);
   }
 
   @override
   EncryptionResult encrypt(List<int> input,
-      {Uint8List initializationVector, Uint8List additionalAuthenticatedData}) {
+      {Uint8List? initializationVector,
+      Uint8List? additionalAuthenticatedData}) {
     _algorithm.init(
         true, pc.ParametersWithRandom(keyParameter, DefaultSecureRandom()));
 
-    return EncryptionResult(_algorithm.process(input));
+    return EncryptionResult(_algorithm.process(input as Uint8List));
   }
 }
 

--- a/lib/src/asymmetric_operator.dart
+++ b/lib/src/asymmetric_operator.dart
@@ -17,22 +17,22 @@ abstract class _AsymmetricOperator<T extends Key> implements Operator<T> {
   }
 
   pc.ECDomainParameters get ecDomainParameters =>
-      createCurveParameters((key as EcKey).curve);
+      createCurveParameters((key as EcKey).curve!);
 
   pc.AsymmetricKeyParameter get keyParameter {
     if (key is RsaPrivateKey) {
       var k = key as RsaPrivateKey;
       return pc.PrivateKeyParameter<pc.RSAPrivateKey>(pc.RSAPrivateKey(
-          k.modulus,
-          k.privateExponent,
+          k.modulus!,
+          k.privateExponent!,
           k.firstPrimeFactor,
           k.secondPrimeFactor));
     }
     if (key is RsaPublicKey) {
       var k = key as RsaPublicKey;
       return pc.PublicKeyParameter<pc.RSAPublicKey>(pc.RSAPublicKey(
-        k.modulus,
-        k.exponent,
+        k.modulus!,
+        k.exponent!,
       ));
     }
     var d = ecDomainParameters;
@@ -47,8 +47,8 @@ abstract class _AsymmetricOperator<T extends Key> implements Operator<T> {
     if (key is EcPublicKey) {
       var k = key as EcPublicKey;
 
-      return pc.PublicKeyParameter<pc.ECPublicKey>(
-          pc.ECPublicKey(d.curve.createPoint(k.xCoordinate, k.yCoordinate), d));
+      return pc.PublicKeyParameter<pc.ECPublicKey>(pc.ECPublicKey(
+          d.curve.createPoint(k.xCoordinate!, k.yCoordinate!), d));
     }
     throw StateError('Unexpected key type ${key}');
   }
@@ -60,7 +60,7 @@ class _AsymmetricSigner extends Signer<PrivateKey>
       : super._(algorithm, key);
 
   @override
-  pc.Signer get _algorithm => super._algorithm;
+  pc.Signer get _algorithm => super._algorithm as pc.Signer;
 
   @override
   Signature sign(List<int> data) {
@@ -80,7 +80,7 @@ class _AsymmetricSigner extends Signer<PrivateKey>
         curves.p256k: 32,
         curves.p384: 48,
         curves.p521: 66
-      }[(key as EcKey).curve];
+      }[(key as EcKey).curve!]!;
       var bytes = Uint8List(length * 2);
       bytes.setRange(
           0, length, _bigIntToBytes(sig.r, length).toList().reversed);
@@ -99,12 +99,13 @@ class _AsymmetricVerifier extends Verifier<PublicKey>
       : super._(algorithm, key);
 
   @override
-  pc.Signer get _algorithm => super._algorithm;
+  pc.Signer get _algorithm => super._algorithm as pc.Signer;
 
   @override
   bool verify(Uint8List data, Signature signature) {
     if (key is RsaKey) {
-      _algorithm.init(false, pc.ParametersWithRandom(keyParameter, null));
+      _algorithm.init(
+          false, pc.ParametersWithRandom(keyParameter, pc.SecureRandom()));
       try {
         return _algorithm.verifySignature(
             data, pc.RSASignature(signature.data));
@@ -132,26 +133,27 @@ class _AsymmetricEncrypter extends Encrypter<Key> with _AsymmetricOperator {
   _AsymmetricEncrypter(Identifier algorithm, Key key) : super._(algorithm, key);
 
   @override
-  pc.AsymmetricBlockCipher get _algorithm => super._algorithm;
+  pc.AsymmetricBlockCipher get _algorithm =>
+      super._algorithm as pc.AsymmetricBlockCipher;
 
   @override
   Uint8List decrypt(EncryptionResult input) {
     _algorithm.init(
         false,
-        pc.ParametersWithRandom(keyParameter, null //pc.SecureRandom('Fortuna')
-            //..seed(pc.KeyParameter(Uint8List(32)))
-            ));
+        pc.ParametersWithRandom(keyParameter,
+            pc.SecureRandom('Fortuna')..seed(pc.KeyParameter(Uint8List(32)))));
 
     return _algorithm.process(input.data);
   }
 
   @override
   EncryptionResult encrypt(List<int> input,
-      {Uint8List initializationVector, Uint8List additionalAuthenticatedData}) {
+      {Uint8List? initializationVector,
+      Uint8List? additionalAuthenticatedData}) {
     _algorithm.init(
         true, pc.ParametersWithRandom(keyParameter, DefaultSecureRandom()));
 
-    return EncryptionResult(_algorithm.process(input));
+    return EncryptionResult(_algorithm.process(input as Uint8List));
   }
 }
 

--- a/lib/src/ec_keys.dart
+++ b/lib/src/ec_keys.dart
@@ -3,29 +3,29 @@ part of '../crypto_keys.dart';
 /// Base class for elliptic curve (EC) keys
 abstract class EcKey extends Key {
   /// The cryptographic curve used with the key
-  Identifier? get curve;
+  Identifier get curve;
 }
 
 /// An elliptic curve (EC) public key
 abstract class EcPublicKey extends EcKey implements PublicKey {
   /// The x coordinate for the Elliptic Curve point
-  BigInt? get xCoordinate;
+  BigInt get xCoordinate;
 
   /// The y coordinate for the Elliptic Curve point
-  BigInt? get yCoordinate;
+  BigInt get yCoordinate;
 
   factory EcPublicKey(
-      {required BigInt? xCoordinate,
-      required BigInt? yCoordinate,
-      required Identifier? curve}) = EcPublicKeyImpl;
+      {@required BigInt xCoordinate,
+      @required BigInt yCoordinate,
+      @required Identifier curve}) = EcPublicKeyImpl;
 }
 
 /// An elliptic curve (EC) private key
 abstract class EcPrivateKey extends EcKey implements PrivateKey {
   /// The Elliptic Curve private key value
-  BigInt? get eccPrivateKey;
+  BigInt get eccPrivateKey;
 
   factory EcPrivateKey(
-      {required BigInt? eccPrivateKey,
-      required Identifier? curve}) = EcPrivateKeyImpl;
+      {@required BigInt eccPrivateKey,
+      @required Identifier curve}) = EcPrivateKeyImpl;
 }

--- a/lib/src/ec_keys.dart
+++ b/lib/src/ec_keys.dart
@@ -3,29 +3,29 @@ part of '../crypto_keys.dart';
 /// Base class for elliptic curve (EC) keys
 abstract class EcKey extends Key {
   /// The cryptographic curve used with the key
-  Identifier get curve;
+  Identifier? get curve;
 }
 
 /// An elliptic curve (EC) public key
 abstract class EcPublicKey extends EcKey implements PublicKey {
   /// The x coordinate for the Elliptic Curve point
-  BigInt get xCoordinate;
+  BigInt? get xCoordinate;
 
   /// The y coordinate for the Elliptic Curve point
-  BigInt get yCoordinate;
+  BigInt? get yCoordinate;
 
   factory EcPublicKey(
-      {@required BigInt xCoordinate,
-      @required BigInt yCoordinate,
-      @required Identifier curve}) = EcPublicKeyImpl;
+      {required BigInt? xCoordinate,
+      required BigInt? yCoordinate,
+      required Identifier? curve}) = EcPublicKeyImpl;
 }
 
 /// An elliptic curve (EC) private key
 abstract class EcPrivateKey extends EcKey implements PrivateKey {
   /// The Elliptic Curve private key value
-  BigInt get eccPrivateKey;
+  BigInt? get eccPrivateKey;
 
   factory EcPrivateKey(
-      {@required BigInt eccPrivateKey,
-      @required Identifier curve}) = EcPrivateKeyImpl;
+      {required BigInt? eccPrivateKey,
+      required Identifier? curve}) = EcPrivateKeyImpl;
 }

--- a/lib/src/impl.dart
+++ b/lib/src/impl.dart
@@ -15,7 +15,7 @@ abstract class RsaPublicKeyImpl extends PublicKey
         Built<RsaPublicKeyImpl, RsaPublicKeyImplBuilder> {
   RsaPublicKeyImpl._();
 
-  factory RsaPublicKeyImpl({BigInt modulus, BigInt exponent}) =
+  factory RsaPublicKeyImpl({BigInt? modulus, BigInt? exponent}) =
       _$RsaPublicKeyImpl._;
 }
 
@@ -28,10 +28,10 @@ abstract class RsaPrivateKeyImpl extends PrivateKey
   RsaPrivateKeyImpl._();
 
   factory RsaPrivateKeyImpl(
-      {BigInt privateExponent,
-      BigInt firstPrimeFactor,
-      BigInt secondPrimeFactor,
-      BigInt modulus}) = _$RsaPrivateKeyImpl._;
+      {BigInt? privateExponent,
+      BigInt? firstPrimeFactor,
+      BigInt? secondPrimeFactor,
+      BigInt? modulus}) = _$RsaPrivateKeyImpl._;
 }
 
 abstract class EcPublicKeyImpl extends PublicKey
@@ -43,9 +43,9 @@ abstract class EcPublicKeyImpl extends PublicKey
   EcPublicKeyImpl._();
 
   factory EcPublicKeyImpl(
-      {BigInt xCoordinate,
-      BigInt yCoordinate,
-      Identifier curve}) = _$EcPublicKeyImpl._;
+      {BigInt? xCoordinate,
+      BigInt? yCoordinate,
+      Identifier? curve}) = _$EcPublicKeyImpl._;
 }
 
 abstract class EcPrivateKeyImpl extends PrivateKey
@@ -56,7 +56,7 @@ abstract class EcPrivateKeyImpl extends PrivateKey
         Built<EcPrivateKeyImpl, EcPrivateKeyImplBuilder> {
   EcPrivateKeyImpl._();
 
-  factory EcPrivateKeyImpl({BigInt eccPrivateKey, Identifier curve}) =
+  factory EcPrivateKeyImpl({BigInt? eccPrivateKey, Identifier? curve}) =
       _$EcPrivateKeyImpl._;
 }
 
@@ -65,16 +65,16 @@ abstract class SymmetricKeyImpl extends Object
     implements SymmetricKey, Built<SymmetricKeyImpl, SymmetricKeyImplBuilder> {
   SymmetricKeyImpl._();
 
-  factory SymmetricKeyImpl({Uint8List keyValue}) = _$SymmetricKeyImpl._;
+  factory SymmetricKeyImpl({Uint8List? keyValue}) = _$SymmetricKeyImpl._;
 }
 
 abstract class SignatureImpl
     implements Signature, Built<SignatureImpl, SignatureImplBuilder> {
-  BuiltList<int> get built_data;
+  BuiltList<int>? get built_data;
 
   @override
   @memoized
-  Uint8List get data => Uint8List.fromList(built_data.asList());
+  Uint8List get data => Uint8List.fromList(built_data!.asList());
 
   SignatureImpl._();
 
@@ -86,46 +86,46 @@ abstract class EncryptionResultImpl
     implements
         EncryptionResult,
         Built<EncryptionResultImpl, EncryptionResultImplBuilder> {
-  BuiltList<int> get built_data;
+  BuiltList<int>? get built_data;
 
   @override
   @memoized
-  Uint8List get data => Uint8List.fromList(built_data.asList());
+  Uint8List get data => Uint8List.fromList(built_data!.asList());
 
   @nullable
-  BuiltList<int> get built_initializationVector;
+  BuiltList<int>? get built_initializationVector;
 
   @override
   @memoized
-  Uint8List get initializationVector => built_initializationVector == null
+  Uint8List? get initializationVector => built_initializationVector == null
       ? null
-      : Uint8List.fromList(built_initializationVector.asList());
+      : Uint8List.fromList(built_initializationVector!.asList());
 
   @nullable
-  BuiltList<int> get built_authenticationTag;
+  BuiltList<int>? get built_authenticationTag;
 
   @override
   @memoized
-  Uint8List get authenticationTag => built_authenticationTag == null
+  Uint8List? get authenticationTag => built_authenticationTag == null
       ? null
-      : Uint8List.fromList(built_authenticationTag.asList());
+      : Uint8List.fromList(built_authenticationTag!.asList());
 
   @nullable
-  BuiltList<int> get built_additionalAuthenticatedData;
+  BuiltList<int>? get built_additionalAuthenticatedData;
 
   @override
   @memoized
-  Uint8List get additionalAuthenticatedData =>
+  Uint8List? get additionalAuthenticatedData =>
       built_additionalAuthenticatedData == null
           ? null
-          : Uint8List.fromList(built_additionalAuthenticatedData.asList());
+          : Uint8List.fromList(built_additionalAuthenticatedData!.asList());
 
   EncryptionResultImpl._();
 
   factory EncryptionResultImpl(Uint8List data,
-          {Uint8List initializationVector,
-          Uint8List authenticationTag,
-          Uint8List additionalAuthenticatedData}) =>
+          {Uint8List? initializationVector,
+          Uint8List? authenticationTag,
+          Uint8List? additionalAuthenticatedData}) =>
       _$EncryptionResultImpl._(
           built_data: BuiltList(data),
           built_initializationVector: initializationVector == null

--- a/lib/src/impl.dart
+++ b/lib/src/impl.dart
@@ -15,7 +15,7 @@ abstract class RsaPublicKeyImpl extends PublicKey
         Built<RsaPublicKeyImpl, RsaPublicKeyImplBuilder> {
   RsaPublicKeyImpl._();
 
-  factory RsaPublicKeyImpl({BigInt? modulus, BigInt? exponent}) =
+  factory RsaPublicKeyImpl({BigInt modulus, BigInt exponent}) =
       _$RsaPublicKeyImpl._;
 }
 
@@ -28,10 +28,10 @@ abstract class RsaPrivateKeyImpl extends PrivateKey
   RsaPrivateKeyImpl._();
 
   factory RsaPrivateKeyImpl(
-      {BigInt? privateExponent,
-      BigInt? firstPrimeFactor,
-      BigInt? secondPrimeFactor,
-      BigInt? modulus}) = _$RsaPrivateKeyImpl._;
+      {BigInt privateExponent,
+      BigInt firstPrimeFactor,
+      BigInt secondPrimeFactor,
+      BigInt modulus}) = _$RsaPrivateKeyImpl._;
 }
 
 abstract class EcPublicKeyImpl extends PublicKey
@@ -43,9 +43,9 @@ abstract class EcPublicKeyImpl extends PublicKey
   EcPublicKeyImpl._();
 
   factory EcPublicKeyImpl(
-      {BigInt? xCoordinate,
-      BigInt? yCoordinate,
-      Identifier? curve}) = _$EcPublicKeyImpl._;
+      {BigInt xCoordinate,
+      BigInt yCoordinate,
+      Identifier curve}) = _$EcPublicKeyImpl._;
 }
 
 abstract class EcPrivateKeyImpl extends PrivateKey
@@ -56,7 +56,7 @@ abstract class EcPrivateKeyImpl extends PrivateKey
         Built<EcPrivateKeyImpl, EcPrivateKeyImplBuilder> {
   EcPrivateKeyImpl._();
 
-  factory EcPrivateKeyImpl({BigInt? eccPrivateKey, Identifier? curve}) =
+  factory EcPrivateKeyImpl({BigInt eccPrivateKey, Identifier curve}) =
       _$EcPrivateKeyImpl._;
 }
 
@@ -65,16 +65,16 @@ abstract class SymmetricKeyImpl extends Object
     implements SymmetricKey, Built<SymmetricKeyImpl, SymmetricKeyImplBuilder> {
   SymmetricKeyImpl._();
 
-  factory SymmetricKeyImpl({Uint8List? keyValue}) = _$SymmetricKeyImpl._;
+  factory SymmetricKeyImpl({Uint8List keyValue}) = _$SymmetricKeyImpl._;
 }
 
 abstract class SignatureImpl
     implements Signature, Built<SignatureImpl, SignatureImplBuilder> {
-  BuiltList<int>? get built_data;
+  BuiltList<int> get built_data;
 
   @override
   @memoized
-  Uint8List get data => Uint8List.fromList(built_data!.asList());
+  Uint8List get data => Uint8List.fromList(built_data.asList());
 
   SignatureImpl._();
 
@@ -86,46 +86,46 @@ abstract class EncryptionResultImpl
     implements
         EncryptionResult,
         Built<EncryptionResultImpl, EncryptionResultImplBuilder> {
-  BuiltList<int>? get built_data;
+  BuiltList<int> get built_data;
 
   @override
   @memoized
-  Uint8List get data => Uint8List.fromList(built_data!.asList());
+  Uint8List get data => Uint8List.fromList(built_data.asList());
 
   @nullable
-  BuiltList<int>? get built_initializationVector;
+  BuiltList<int> get built_initializationVector;
 
   @override
   @memoized
-  Uint8List? get initializationVector => built_initializationVector == null
+  Uint8List get initializationVector => built_initializationVector == null
       ? null
-      : Uint8List.fromList(built_initializationVector!.asList());
+      : Uint8List.fromList(built_initializationVector.asList());
 
   @nullable
-  BuiltList<int>? get built_authenticationTag;
+  BuiltList<int> get built_authenticationTag;
 
   @override
   @memoized
-  Uint8List? get authenticationTag => built_authenticationTag == null
+  Uint8List get authenticationTag => built_authenticationTag == null
       ? null
-      : Uint8List.fromList(built_authenticationTag!.asList());
+      : Uint8List.fromList(built_authenticationTag.asList());
 
   @nullable
-  BuiltList<int>? get built_additionalAuthenticatedData;
+  BuiltList<int> get built_additionalAuthenticatedData;
 
   @override
   @memoized
-  Uint8List? get additionalAuthenticatedData =>
+  Uint8List get additionalAuthenticatedData =>
       built_additionalAuthenticatedData == null
           ? null
-          : Uint8List.fromList(built_additionalAuthenticatedData!.asList());
+          : Uint8List.fromList(built_additionalAuthenticatedData.asList());
 
   EncryptionResultImpl._();
 
   factory EncryptionResultImpl(Uint8List data,
-          {Uint8List? initializationVector,
-          Uint8List? authenticationTag,
-          Uint8List? additionalAuthenticatedData}) =>
+          {Uint8List initializationVector,
+          Uint8List authenticationTag,
+          Uint8List additionalAuthenticatedData}) =>
       _$EncryptionResultImpl._(
           built_data: BuiltList(data),
           built_initializationVector: initializationVector == null

--- a/lib/src/impl.g.dart
+++ b/lib/src/impl.g.dart
@@ -18,12 +18,12 @@ part of 'impl.dart';
 
 class _$RsaPublicKeyImpl extends RsaPublicKeyImpl {
   @override
-  final BigInt? exponent;
+  final BigInt exponent;
   @override
-  final BigInt? modulus;
+  final BigInt modulus;
 
   factory _$RsaPublicKeyImpl(
-          [void Function(RsaPublicKeyImplBuilder b)? updates]) =>
+          [void Function(RsaPublicKeyImplBuilder b) updates]) =>
       (RsaPublicKeyImplBuilder()..update(updates)).build();
 
   _$RsaPublicKeyImpl._({this.exponent, this.modulus}) : super._() {
@@ -66,26 +66,26 @@ class _$RsaPublicKeyImpl extends RsaPublicKeyImpl {
 
 class RsaPublicKeyImplBuilder
     implements Builder<RsaPublicKeyImpl, RsaPublicKeyImplBuilder> {
-  _$RsaPublicKeyImpl? _$v;
+  _$RsaPublicKeyImpl _$v;
 
-  BigInt? _exponent;
+  BigInt _exponent;
 
-  BigInt? get exponent => _$this._exponent;
+  BigInt get exponent => _$this._exponent;
 
-  set exponent(BigInt? exponent) => _$this._exponent = exponent;
+  set exponent(BigInt exponent) => _$this._exponent = exponent;
 
-  BigInt? _modulus;
+  BigInt _modulus;
 
-  BigInt? get modulus => _$this._modulus;
+  BigInt get modulus => _$this._modulus;
 
-  set modulus(BigInt? modulus) => _$this._modulus = modulus;
+  set modulus(BigInt modulus) => _$this._modulus = modulus;
 
   RsaPublicKeyImplBuilder();
 
   RsaPublicKeyImplBuilder get _$this {
     if (_$v != null) {
-      _exponent = _$v!.exponent;
-      _modulus = _$v!.modulus;
+      _exponent = _$v.exponent;
+      _modulus = _$v.modulus;
       _$v = null;
     }
     return this;
@@ -98,7 +98,7 @@ class RsaPublicKeyImplBuilder
   }
 
   @override
-  void update(void Function(RsaPublicKeyImplBuilder b)? updates) {
+  void update(void Function(RsaPublicKeyImplBuilder b) updates) {
     if (updates != null) updates(this);
   }
 
@@ -113,16 +113,16 @@ class RsaPublicKeyImplBuilder
 
 class _$RsaPrivateKeyImpl extends RsaPrivateKeyImpl {
   @override
-  final BigInt? privateExponent;
+  final BigInt privateExponent;
   @override
-  final BigInt? firstPrimeFactor;
+  final BigInt firstPrimeFactor;
   @override
-  final BigInt? secondPrimeFactor;
+  final BigInt secondPrimeFactor;
   @override
-  final BigInt? modulus;
+  final BigInt modulus;
 
   factory _$RsaPrivateKeyImpl(
-          [void Function(RsaPrivateKeyImplBuilder b)? updates]) =>
+          [void Function(RsaPrivateKeyImplBuilder b) updates]) =>
       (RsaPrivateKeyImplBuilder()..update(updates)).build();
 
   _$RsaPrivateKeyImpl._(
@@ -185,43 +185,43 @@ class _$RsaPrivateKeyImpl extends RsaPrivateKeyImpl {
 
 class RsaPrivateKeyImplBuilder
     implements Builder<RsaPrivateKeyImpl, RsaPrivateKeyImplBuilder> {
-  _$RsaPrivateKeyImpl? _$v;
+  _$RsaPrivateKeyImpl _$v;
 
-  BigInt? _privateExponent;
+  BigInt _privateExponent;
 
-  BigInt? get privateExponent => _$this._privateExponent;
+  BigInt get privateExponent => _$this._privateExponent;
 
-  set privateExponent(BigInt? privateExponent) =>
+  set privateExponent(BigInt privateExponent) =>
       _$this._privateExponent = privateExponent;
 
-  BigInt? _firstPrimeFactor;
+  BigInt _firstPrimeFactor;
 
-  BigInt? get firstPrimeFactor => _$this._firstPrimeFactor;
+  BigInt get firstPrimeFactor => _$this._firstPrimeFactor;
 
-  set firstPrimeFactor(BigInt? firstPrimeFactor) =>
+  set firstPrimeFactor(BigInt firstPrimeFactor) =>
       _$this._firstPrimeFactor = firstPrimeFactor;
 
-  BigInt? _secondPrimeFactor;
+  BigInt _secondPrimeFactor;
 
-  BigInt? get secondPrimeFactor => _$this._secondPrimeFactor;
+  BigInt get secondPrimeFactor => _$this._secondPrimeFactor;
 
-  set secondPrimeFactor(BigInt? secondPrimeFactor) =>
+  set secondPrimeFactor(BigInt secondPrimeFactor) =>
       _$this._secondPrimeFactor = secondPrimeFactor;
 
-  BigInt? _modulus;
+  BigInt _modulus;
 
-  BigInt? get modulus => _$this._modulus;
+  BigInt get modulus => _$this._modulus;
 
-  set modulus(BigInt? modulus) => _$this._modulus = modulus;
+  set modulus(BigInt modulus) => _$this._modulus = modulus;
 
   RsaPrivateKeyImplBuilder();
 
   RsaPrivateKeyImplBuilder get _$this {
     if (_$v != null) {
-      _privateExponent = _$v!.privateExponent;
-      _firstPrimeFactor = _$v!.firstPrimeFactor;
-      _secondPrimeFactor = _$v!.secondPrimeFactor;
-      _modulus = _$v!.modulus;
+      _privateExponent = _$v.privateExponent;
+      _firstPrimeFactor = _$v.firstPrimeFactor;
+      _secondPrimeFactor = _$v.secondPrimeFactor;
+      _modulus = _$v.modulus;
       _$v = null;
     }
     return this;
@@ -234,7 +234,7 @@ class RsaPrivateKeyImplBuilder
   }
 
   @override
-  void update(void Function(RsaPrivateKeyImplBuilder b)? updates) {
+  void update(void Function(RsaPrivateKeyImplBuilder b) updates) {
     if (updates != null) updates(this);
   }
 
@@ -253,14 +253,14 @@ class RsaPrivateKeyImplBuilder
 
 class _$EcPublicKeyImpl extends EcPublicKeyImpl {
   @override
-  final BigInt? xCoordinate;
+  final BigInt xCoordinate;
   @override
-  final BigInt? yCoordinate;
+  final BigInt yCoordinate;
   @override
-  final Identifier? curve;
+  final Identifier curve;
 
   factory _$EcPublicKeyImpl(
-          [void Function(EcPublicKeyImplBuilder b)? updates]) =>
+          [void Function(EcPublicKeyImplBuilder b) updates]) =>
       (EcPublicKeyImplBuilder()..update(updates)).build();
 
   _$EcPublicKeyImpl._({this.xCoordinate, this.yCoordinate, this.curve})
@@ -310,33 +310,33 @@ class _$EcPublicKeyImpl extends EcPublicKeyImpl {
 
 class EcPublicKeyImplBuilder
     implements Builder<EcPublicKeyImpl, EcPublicKeyImplBuilder> {
-  _$EcPublicKeyImpl? _$v;
+  _$EcPublicKeyImpl _$v;
 
-  BigInt? _xCoordinate;
+  BigInt _xCoordinate;
 
-  BigInt? get xCoordinate => _$this._xCoordinate;
+  BigInt get xCoordinate => _$this._xCoordinate;
 
-  set xCoordinate(BigInt? xCoordinate) => _$this._xCoordinate = xCoordinate;
+  set xCoordinate(BigInt xCoordinate) => _$this._xCoordinate = xCoordinate;
 
-  BigInt? _yCoordinate;
+  BigInt _yCoordinate;
 
-  BigInt? get yCoordinate => _$this._yCoordinate;
+  BigInt get yCoordinate => _$this._yCoordinate;
 
-  set yCoordinate(BigInt? yCoordinate) => _$this._yCoordinate = yCoordinate;
+  set yCoordinate(BigInt yCoordinate) => _$this._yCoordinate = yCoordinate;
 
-  Identifier? _curve;
+  Identifier _curve;
 
-  Identifier? get curve => _$this._curve;
+  Identifier get curve => _$this._curve;
 
-  set curve(Identifier? curve) => _$this._curve = curve;
+  set curve(Identifier curve) => _$this._curve = curve;
 
   EcPublicKeyImplBuilder();
 
   EcPublicKeyImplBuilder get _$this {
     if (_$v != null) {
-      _xCoordinate = _$v!.xCoordinate;
-      _yCoordinate = _$v!.yCoordinate;
-      _curve = _$v!.curve;
+      _xCoordinate = _$v.xCoordinate;
+      _yCoordinate = _$v.yCoordinate;
+      _curve = _$v.curve;
       _$v = null;
     }
     return this;
@@ -349,7 +349,7 @@ class EcPublicKeyImplBuilder
   }
 
   @override
-  void update(void Function(EcPublicKeyImplBuilder b)? updates) {
+  void update(void Function(EcPublicKeyImplBuilder b) updates) {
     if (updates != null) updates(this);
   }
 
@@ -365,12 +365,12 @@ class EcPublicKeyImplBuilder
 
 class _$EcPrivateKeyImpl extends EcPrivateKeyImpl {
   @override
-  final BigInt? eccPrivateKey;
+  final BigInt eccPrivateKey;
   @override
-  final Identifier? curve;
+  final Identifier curve;
 
   factory _$EcPrivateKeyImpl(
-          [void Function(EcPrivateKeyImplBuilder b)? updates]) =>
+          [void Function(EcPrivateKeyImplBuilder b) updates]) =>
       (EcPrivateKeyImplBuilder()..update(updates)).build();
 
   _$EcPrivateKeyImpl._({this.eccPrivateKey, this.curve}) : super._() {
@@ -413,27 +413,27 @@ class _$EcPrivateKeyImpl extends EcPrivateKeyImpl {
 
 class EcPrivateKeyImplBuilder
     implements Builder<EcPrivateKeyImpl, EcPrivateKeyImplBuilder> {
-  _$EcPrivateKeyImpl? _$v;
+  _$EcPrivateKeyImpl _$v;
 
-  BigInt? _eccPrivateKey;
+  BigInt _eccPrivateKey;
 
-  BigInt? get eccPrivateKey => _$this._eccPrivateKey;
+  BigInt get eccPrivateKey => _$this._eccPrivateKey;
 
-  set eccPrivateKey(BigInt? eccPrivateKey) =>
+  set eccPrivateKey(BigInt eccPrivateKey) =>
       _$this._eccPrivateKey = eccPrivateKey;
 
-  Identifier? _curve;
+  Identifier _curve;
 
-  Identifier? get curve => _$this._curve;
+  Identifier get curve => _$this._curve;
 
-  set curve(Identifier? curve) => _$this._curve = curve;
+  set curve(Identifier curve) => _$this._curve = curve;
 
   EcPrivateKeyImplBuilder();
 
   EcPrivateKeyImplBuilder get _$this {
     if (_$v != null) {
-      _eccPrivateKey = _$v!.eccPrivateKey;
-      _curve = _$v!.curve;
+      _eccPrivateKey = _$v.eccPrivateKey;
+      _curve = _$v.curve;
       _$v = null;
     }
     return this;
@@ -446,7 +446,7 @@ class EcPrivateKeyImplBuilder
   }
 
   @override
-  void update(void Function(EcPrivateKeyImplBuilder b)? updates) {
+  void update(void Function(EcPrivateKeyImplBuilder b) updates) {
     if (updates != null) updates(this);
   }
 
@@ -461,10 +461,10 @@ class EcPrivateKeyImplBuilder
 
 class _$SymmetricKeyImpl extends SymmetricKeyImpl {
   @override
-  final Uint8List? keyValue;
+  final Uint8List keyValue;
 
   factory _$SymmetricKeyImpl(
-          [void Function(SymmetricKeyImplBuilder b)? updates]) =>
+          [void Function(SymmetricKeyImplBuilder b) updates]) =>
       (SymmetricKeyImplBuilder()..update(updates)).build();
 
   _$SymmetricKeyImpl._({this.keyValue}) : super._() {
@@ -503,19 +503,19 @@ class _$SymmetricKeyImpl extends SymmetricKeyImpl {
 
 class SymmetricKeyImplBuilder
     implements Builder<SymmetricKeyImpl, SymmetricKeyImplBuilder> {
-  _$SymmetricKeyImpl? _$v;
+  _$SymmetricKeyImpl _$v;
 
-  Uint8List? _keyValue;
+  Uint8List _keyValue;
 
-  Uint8List? get keyValue => _$this._keyValue;
+  Uint8List get keyValue => _$this._keyValue;
 
-  set keyValue(Uint8List? keyValue) => _$this._keyValue = keyValue;
+  set keyValue(Uint8List keyValue) => _$this._keyValue = keyValue;
 
   SymmetricKeyImplBuilder();
 
   SymmetricKeyImplBuilder get _$this {
     if (_$v != null) {
-      _keyValue = _$v!.keyValue;
+      _keyValue = _$v.keyValue;
       _$v = null;
     }
     return this;
@@ -528,7 +528,7 @@ class SymmetricKeyImplBuilder
   }
 
   @override
-  void update(void Function(SymmetricKeyImplBuilder b)? updates) {
+  void update(void Function(SymmetricKeyImplBuilder b) updates) {
     if (updates != null) updates(this);
   }
 
@@ -542,10 +542,10 @@ class SymmetricKeyImplBuilder
 
 class _$SignatureImpl extends SignatureImpl {
   @override
-  final BuiltList<int>? built_data;
-  Uint8List? __data;
+  final BuiltList<int> built_data;
+  Uint8List __data;
 
-  factory _$SignatureImpl([void Function(SignatureImplBuilder b)? updates]) =>
+  factory _$SignatureImpl([void Function(SignatureImplBuilder b) updates]) =>
       (SignatureImplBuilder()..update(updates)).build();
 
   _$SignatureImpl._({this.built_data}) : super._() {
@@ -586,9 +586,9 @@ class _$SignatureImpl extends SignatureImpl {
 
 class SignatureImplBuilder
     implements Builder<SignatureImpl, SignatureImplBuilder> {
-  _$SignatureImpl? _$v;
+  _$SignatureImpl _$v;
 
-  ListBuilder<int>? _built_data;
+  ListBuilder<int> _built_data;
 
   ListBuilder<int> get built_data => _$this._built_data ??= ListBuilder<int>();
 
@@ -599,7 +599,7 @@ class SignatureImplBuilder
 
   SignatureImplBuilder get _$this {
     if (_$v != null) {
-      _built_data = _$v!.built_data?.toBuilder();
+      _built_data = _$v.built_data?.toBuilder();
       _$v = null;
     }
     return this;
@@ -612,7 +612,7 @@ class SignatureImplBuilder
   }
 
   @override
-  void update(void Function(SignatureImplBuilder b)? updates) {
+  void update(void Function(SignatureImplBuilder b) updates) {
     if (updates != null) updates(this);
   }
 
@@ -622,7 +622,7 @@ class SignatureImplBuilder
     try {
       _$result = _$v ?? _$SignatureImpl._(built_data: built_data.build());
     } catch (_) {
-      late String _$failedField;
+      String _$failedField;
       try {
         _$failedField = 'built_data';
         built_data.build();
@@ -639,20 +639,20 @@ class SignatureImplBuilder
 
 class _$EncryptionResultImpl extends EncryptionResultImpl {
   @override
-  final BuiltList<int>? built_data;
+  final BuiltList<int> built_data;
   @override
-  final BuiltList<int>? built_initializationVector;
+  final BuiltList<int> built_initializationVector;
   @override
-  final BuiltList<int>? built_authenticationTag;
+  final BuiltList<int> built_authenticationTag;
   @override
-  final BuiltList<int>? built_additionalAuthenticatedData;
-  Uint8List? __data;
-  Uint8List? __initializationVector;
-  Uint8List? __authenticationTag;
-  Uint8List? __additionalAuthenticatedData;
+  final BuiltList<int> built_additionalAuthenticatedData;
+  Uint8List __data;
+  Uint8List __initializationVector;
+  Uint8List __authenticationTag;
+  Uint8List __additionalAuthenticatedData;
 
   factory _$EncryptionResultImpl(
-          [void Function(EncryptionResultImplBuilder b)? updates]) =>
+          [void Function(EncryptionResultImplBuilder b) updates]) =>
       (EncryptionResultImplBuilder()..update(updates)).build();
 
   _$EncryptionResultImpl._(
@@ -670,15 +670,15 @@ class _$EncryptionResultImpl extends EncryptionResultImpl {
   Uint8List get data => __data ??= super.data;
 
   @override
-  Uint8List? get initializationVector =>
+  Uint8List get initializationVector =>
       __initializationVector ??= super.initializationVector;
 
   @override
-  Uint8List? get authenticationTag =>
+  Uint8List get authenticationTag =>
       __authenticationTag ??= super.authenticationTag;
 
   @override
-  Uint8List? get additionalAuthenticatedData =>
+  Uint8List get additionalAuthenticatedData =>
       __additionalAuthenticatedData ??= super.additionalAuthenticatedData;
 
   @override
@@ -725,16 +725,16 @@ class _$EncryptionResultImpl extends EncryptionResultImpl {
 
 class EncryptionResultImplBuilder
     implements Builder<EncryptionResultImpl, EncryptionResultImplBuilder> {
-  _$EncryptionResultImpl? _$v;
+  _$EncryptionResultImpl _$v;
 
-  ListBuilder<int>? _built_data;
+  ListBuilder<int> _built_data;
 
   ListBuilder<int> get built_data => _$this._built_data ??= ListBuilder<int>();
 
   set built_data(ListBuilder<int> built_data) =>
       _$this._built_data = built_data;
 
-  ListBuilder<int>? _built_initializationVector;
+  ListBuilder<int> _built_initializationVector;
 
   ListBuilder<int> get built_initializationVector =>
       _$this._built_initializationVector ??= ListBuilder<int>();
@@ -742,7 +742,7 @@ class EncryptionResultImplBuilder
   set built_initializationVector(ListBuilder<int> built_initializationVector) =>
       _$this._built_initializationVector = built_initializationVector;
 
-  ListBuilder<int>? _built_authenticationTag;
+  ListBuilder<int> _built_authenticationTag;
 
   ListBuilder<int> get built_authenticationTag =>
       _$this._built_authenticationTag ??= ListBuilder<int>();
@@ -750,7 +750,7 @@ class EncryptionResultImplBuilder
   set built_authenticationTag(ListBuilder<int> built_authenticationTag) =>
       _$this._built_authenticationTag = built_authenticationTag;
 
-  ListBuilder<int>? _built_additionalAuthenticatedData;
+  ListBuilder<int> _built_additionalAuthenticatedData;
 
   ListBuilder<int> get built_additionalAuthenticatedData =>
       _$this._built_additionalAuthenticatedData ??= ListBuilder<int>();
@@ -764,11 +764,11 @@ class EncryptionResultImplBuilder
 
   EncryptionResultImplBuilder get _$this {
     if (_$v != null) {
-      _built_data = _$v!.built_data?.toBuilder();
-      _built_initializationVector = _$v!.built_initializationVector?.toBuilder();
-      _built_authenticationTag = _$v!.built_authenticationTag?.toBuilder();
+      _built_data = _$v.built_data?.toBuilder();
+      _built_initializationVector = _$v.built_initializationVector?.toBuilder();
+      _built_authenticationTag = _$v.built_authenticationTag?.toBuilder();
       _built_additionalAuthenticatedData =
-          _$v!.built_additionalAuthenticatedData?.toBuilder();
+          _$v.built_additionalAuthenticatedData?.toBuilder();
       _$v = null;
     }
     return this;
@@ -781,7 +781,7 @@ class EncryptionResultImplBuilder
   }
 
   @override
-  void update(void Function(EncryptionResultImplBuilder b)? updates) {
+  void update(void Function(EncryptionResultImplBuilder b) updates) {
     if (updates != null) updates(this);
   }
 
@@ -797,7 +797,7 @@ class EncryptionResultImplBuilder
               built_additionalAuthenticatedData:
                   _built_additionalAuthenticatedData?.build());
     } catch (_) {
-      late String _$failedField;
+      String _$failedField;
       try {
         _$failedField = 'built_data';
         built_data.build();

--- a/lib/src/impl.g.dart
+++ b/lib/src/impl.g.dart
@@ -18,12 +18,12 @@ part of 'impl.dart';
 
 class _$RsaPublicKeyImpl extends RsaPublicKeyImpl {
   @override
-  final BigInt exponent;
+  final BigInt? exponent;
   @override
-  final BigInt modulus;
+  final BigInt? modulus;
 
   factory _$RsaPublicKeyImpl(
-          [void Function(RsaPublicKeyImplBuilder b) updates]) =>
+          [void Function(RsaPublicKeyImplBuilder b)? updates]) =>
       (RsaPublicKeyImplBuilder()..update(updates)).build();
 
   _$RsaPublicKeyImpl._({this.exponent, this.modulus}) : super._() {
@@ -66,26 +66,26 @@ class _$RsaPublicKeyImpl extends RsaPublicKeyImpl {
 
 class RsaPublicKeyImplBuilder
     implements Builder<RsaPublicKeyImpl, RsaPublicKeyImplBuilder> {
-  _$RsaPublicKeyImpl _$v;
+  _$RsaPublicKeyImpl? _$v;
 
-  BigInt _exponent;
+  BigInt? _exponent;
 
-  BigInt get exponent => _$this._exponent;
+  BigInt? get exponent => _$this._exponent;
 
-  set exponent(BigInt exponent) => _$this._exponent = exponent;
+  set exponent(BigInt? exponent) => _$this._exponent = exponent;
 
-  BigInt _modulus;
+  BigInt? _modulus;
 
-  BigInt get modulus => _$this._modulus;
+  BigInt? get modulus => _$this._modulus;
 
-  set modulus(BigInt modulus) => _$this._modulus = modulus;
+  set modulus(BigInt? modulus) => _$this._modulus = modulus;
 
   RsaPublicKeyImplBuilder();
 
   RsaPublicKeyImplBuilder get _$this {
     if (_$v != null) {
-      _exponent = _$v.exponent;
-      _modulus = _$v.modulus;
+      _exponent = _$v!.exponent;
+      _modulus = _$v!.modulus;
       _$v = null;
     }
     return this;
@@ -98,7 +98,7 @@ class RsaPublicKeyImplBuilder
   }
 
   @override
-  void update(void Function(RsaPublicKeyImplBuilder b) updates) {
+  void update(void Function(RsaPublicKeyImplBuilder b)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -113,16 +113,16 @@ class RsaPublicKeyImplBuilder
 
 class _$RsaPrivateKeyImpl extends RsaPrivateKeyImpl {
   @override
-  final BigInt privateExponent;
+  final BigInt? privateExponent;
   @override
-  final BigInt firstPrimeFactor;
+  final BigInt? firstPrimeFactor;
   @override
-  final BigInt secondPrimeFactor;
+  final BigInt? secondPrimeFactor;
   @override
-  final BigInt modulus;
+  final BigInt? modulus;
 
   factory _$RsaPrivateKeyImpl(
-          [void Function(RsaPrivateKeyImplBuilder b) updates]) =>
+          [void Function(RsaPrivateKeyImplBuilder b)? updates]) =>
       (RsaPrivateKeyImplBuilder()..update(updates)).build();
 
   _$RsaPrivateKeyImpl._(
@@ -185,43 +185,43 @@ class _$RsaPrivateKeyImpl extends RsaPrivateKeyImpl {
 
 class RsaPrivateKeyImplBuilder
     implements Builder<RsaPrivateKeyImpl, RsaPrivateKeyImplBuilder> {
-  _$RsaPrivateKeyImpl _$v;
+  _$RsaPrivateKeyImpl? _$v;
 
-  BigInt _privateExponent;
+  BigInt? _privateExponent;
 
-  BigInt get privateExponent => _$this._privateExponent;
+  BigInt? get privateExponent => _$this._privateExponent;
 
-  set privateExponent(BigInt privateExponent) =>
+  set privateExponent(BigInt? privateExponent) =>
       _$this._privateExponent = privateExponent;
 
-  BigInt _firstPrimeFactor;
+  BigInt? _firstPrimeFactor;
 
-  BigInt get firstPrimeFactor => _$this._firstPrimeFactor;
+  BigInt? get firstPrimeFactor => _$this._firstPrimeFactor;
 
-  set firstPrimeFactor(BigInt firstPrimeFactor) =>
+  set firstPrimeFactor(BigInt? firstPrimeFactor) =>
       _$this._firstPrimeFactor = firstPrimeFactor;
 
-  BigInt _secondPrimeFactor;
+  BigInt? _secondPrimeFactor;
 
-  BigInt get secondPrimeFactor => _$this._secondPrimeFactor;
+  BigInt? get secondPrimeFactor => _$this._secondPrimeFactor;
 
-  set secondPrimeFactor(BigInt secondPrimeFactor) =>
+  set secondPrimeFactor(BigInt? secondPrimeFactor) =>
       _$this._secondPrimeFactor = secondPrimeFactor;
 
-  BigInt _modulus;
+  BigInt? _modulus;
 
-  BigInt get modulus => _$this._modulus;
+  BigInt? get modulus => _$this._modulus;
 
-  set modulus(BigInt modulus) => _$this._modulus = modulus;
+  set modulus(BigInt? modulus) => _$this._modulus = modulus;
 
   RsaPrivateKeyImplBuilder();
 
   RsaPrivateKeyImplBuilder get _$this {
     if (_$v != null) {
-      _privateExponent = _$v.privateExponent;
-      _firstPrimeFactor = _$v.firstPrimeFactor;
-      _secondPrimeFactor = _$v.secondPrimeFactor;
-      _modulus = _$v.modulus;
+      _privateExponent = _$v!.privateExponent;
+      _firstPrimeFactor = _$v!.firstPrimeFactor;
+      _secondPrimeFactor = _$v!.secondPrimeFactor;
+      _modulus = _$v!.modulus;
       _$v = null;
     }
     return this;
@@ -234,7 +234,7 @@ class RsaPrivateKeyImplBuilder
   }
 
   @override
-  void update(void Function(RsaPrivateKeyImplBuilder b) updates) {
+  void update(void Function(RsaPrivateKeyImplBuilder b)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -253,14 +253,14 @@ class RsaPrivateKeyImplBuilder
 
 class _$EcPublicKeyImpl extends EcPublicKeyImpl {
   @override
-  final BigInt xCoordinate;
+  final BigInt? xCoordinate;
   @override
-  final BigInt yCoordinate;
+  final BigInt? yCoordinate;
   @override
-  final Identifier curve;
+  final Identifier? curve;
 
   factory _$EcPublicKeyImpl(
-          [void Function(EcPublicKeyImplBuilder b) updates]) =>
+          [void Function(EcPublicKeyImplBuilder b)? updates]) =>
       (EcPublicKeyImplBuilder()..update(updates)).build();
 
   _$EcPublicKeyImpl._({this.xCoordinate, this.yCoordinate, this.curve})
@@ -310,33 +310,33 @@ class _$EcPublicKeyImpl extends EcPublicKeyImpl {
 
 class EcPublicKeyImplBuilder
     implements Builder<EcPublicKeyImpl, EcPublicKeyImplBuilder> {
-  _$EcPublicKeyImpl _$v;
+  _$EcPublicKeyImpl? _$v;
 
-  BigInt _xCoordinate;
+  BigInt? _xCoordinate;
 
-  BigInt get xCoordinate => _$this._xCoordinate;
+  BigInt? get xCoordinate => _$this._xCoordinate;
 
-  set xCoordinate(BigInt xCoordinate) => _$this._xCoordinate = xCoordinate;
+  set xCoordinate(BigInt? xCoordinate) => _$this._xCoordinate = xCoordinate;
 
-  BigInt _yCoordinate;
+  BigInt? _yCoordinate;
 
-  BigInt get yCoordinate => _$this._yCoordinate;
+  BigInt? get yCoordinate => _$this._yCoordinate;
 
-  set yCoordinate(BigInt yCoordinate) => _$this._yCoordinate = yCoordinate;
+  set yCoordinate(BigInt? yCoordinate) => _$this._yCoordinate = yCoordinate;
 
-  Identifier _curve;
+  Identifier? _curve;
 
-  Identifier get curve => _$this._curve;
+  Identifier? get curve => _$this._curve;
 
-  set curve(Identifier curve) => _$this._curve = curve;
+  set curve(Identifier? curve) => _$this._curve = curve;
 
   EcPublicKeyImplBuilder();
 
   EcPublicKeyImplBuilder get _$this {
     if (_$v != null) {
-      _xCoordinate = _$v.xCoordinate;
-      _yCoordinate = _$v.yCoordinate;
-      _curve = _$v.curve;
+      _xCoordinate = _$v!.xCoordinate;
+      _yCoordinate = _$v!.yCoordinate;
+      _curve = _$v!.curve;
       _$v = null;
     }
     return this;
@@ -349,7 +349,7 @@ class EcPublicKeyImplBuilder
   }
 
   @override
-  void update(void Function(EcPublicKeyImplBuilder b) updates) {
+  void update(void Function(EcPublicKeyImplBuilder b)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -365,12 +365,12 @@ class EcPublicKeyImplBuilder
 
 class _$EcPrivateKeyImpl extends EcPrivateKeyImpl {
   @override
-  final BigInt eccPrivateKey;
+  final BigInt? eccPrivateKey;
   @override
-  final Identifier curve;
+  final Identifier? curve;
 
   factory _$EcPrivateKeyImpl(
-          [void Function(EcPrivateKeyImplBuilder b) updates]) =>
+          [void Function(EcPrivateKeyImplBuilder b)? updates]) =>
       (EcPrivateKeyImplBuilder()..update(updates)).build();
 
   _$EcPrivateKeyImpl._({this.eccPrivateKey, this.curve}) : super._() {
@@ -413,27 +413,27 @@ class _$EcPrivateKeyImpl extends EcPrivateKeyImpl {
 
 class EcPrivateKeyImplBuilder
     implements Builder<EcPrivateKeyImpl, EcPrivateKeyImplBuilder> {
-  _$EcPrivateKeyImpl _$v;
+  _$EcPrivateKeyImpl? _$v;
 
-  BigInt _eccPrivateKey;
+  BigInt? _eccPrivateKey;
 
-  BigInt get eccPrivateKey => _$this._eccPrivateKey;
+  BigInt? get eccPrivateKey => _$this._eccPrivateKey;
 
-  set eccPrivateKey(BigInt eccPrivateKey) =>
+  set eccPrivateKey(BigInt? eccPrivateKey) =>
       _$this._eccPrivateKey = eccPrivateKey;
 
-  Identifier _curve;
+  Identifier? _curve;
 
-  Identifier get curve => _$this._curve;
+  Identifier? get curve => _$this._curve;
 
-  set curve(Identifier curve) => _$this._curve = curve;
+  set curve(Identifier? curve) => _$this._curve = curve;
 
   EcPrivateKeyImplBuilder();
 
   EcPrivateKeyImplBuilder get _$this {
     if (_$v != null) {
-      _eccPrivateKey = _$v.eccPrivateKey;
-      _curve = _$v.curve;
+      _eccPrivateKey = _$v!.eccPrivateKey;
+      _curve = _$v!.curve;
       _$v = null;
     }
     return this;
@@ -446,7 +446,7 @@ class EcPrivateKeyImplBuilder
   }
 
   @override
-  void update(void Function(EcPrivateKeyImplBuilder b) updates) {
+  void update(void Function(EcPrivateKeyImplBuilder b)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -461,10 +461,10 @@ class EcPrivateKeyImplBuilder
 
 class _$SymmetricKeyImpl extends SymmetricKeyImpl {
   @override
-  final Uint8List keyValue;
+  final Uint8List? keyValue;
 
   factory _$SymmetricKeyImpl(
-          [void Function(SymmetricKeyImplBuilder b) updates]) =>
+          [void Function(SymmetricKeyImplBuilder b)? updates]) =>
       (SymmetricKeyImplBuilder()..update(updates)).build();
 
   _$SymmetricKeyImpl._({this.keyValue}) : super._() {
@@ -503,19 +503,19 @@ class _$SymmetricKeyImpl extends SymmetricKeyImpl {
 
 class SymmetricKeyImplBuilder
     implements Builder<SymmetricKeyImpl, SymmetricKeyImplBuilder> {
-  _$SymmetricKeyImpl _$v;
+  _$SymmetricKeyImpl? _$v;
 
-  Uint8List _keyValue;
+  Uint8List? _keyValue;
 
-  Uint8List get keyValue => _$this._keyValue;
+  Uint8List? get keyValue => _$this._keyValue;
 
-  set keyValue(Uint8List keyValue) => _$this._keyValue = keyValue;
+  set keyValue(Uint8List? keyValue) => _$this._keyValue = keyValue;
 
   SymmetricKeyImplBuilder();
 
   SymmetricKeyImplBuilder get _$this {
     if (_$v != null) {
-      _keyValue = _$v.keyValue;
+      _keyValue = _$v!.keyValue;
       _$v = null;
     }
     return this;
@@ -528,7 +528,7 @@ class SymmetricKeyImplBuilder
   }
 
   @override
-  void update(void Function(SymmetricKeyImplBuilder b) updates) {
+  void update(void Function(SymmetricKeyImplBuilder b)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -542,10 +542,10 @@ class SymmetricKeyImplBuilder
 
 class _$SignatureImpl extends SignatureImpl {
   @override
-  final BuiltList<int> built_data;
-  Uint8List __data;
+  final BuiltList<int>? built_data;
+  Uint8List? __data;
 
-  factory _$SignatureImpl([void Function(SignatureImplBuilder b) updates]) =>
+  factory _$SignatureImpl([void Function(SignatureImplBuilder b)? updates]) =>
       (SignatureImplBuilder()..update(updates)).build();
 
   _$SignatureImpl._({this.built_data}) : super._() {
@@ -586,9 +586,9 @@ class _$SignatureImpl extends SignatureImpl {
 
 class SignatureImplBuilder
     implements Builder<SignatureImpl, SignatureImplBuilder> {
-  _$SignatureImpl _$v;
+  _$SignatureImpl? _$v;
 
-  ListBuilder<int> _built_data;
+  ListBuilder<int>? _built_data;
 
   ListBuilder<int> get built_data => _$this._built_data ??= ListBuilder<int>();
 
@@ -599,7 +599,7 @@ class SignatureImplBuilder
 
   SignatureImplBuilder get _$this {
     if (_$v != null) {
-      _built_data = _$v.built_data?.toBuilder();
+      _built_data = _$v!.built_data?.toBuilder();
       _$v = null;
     }
     return this;
@@ -612,7 +612,7 @@ class SignatureImplBuilder
   }
 
   @override
-  void update(void Function(SignatureImplBuilder b) updates) {
+  void update(void Function(SignatureImplBuilder b)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -622,7 +622,7 @@ class SignatureImplBuilder
     try {
       _$result = _$v ?? _$SignatureImpl._(built_data: built_data.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'built_data';
         built_data.build();
@@ -639,20 +639,20 @@ class SignatureImplBuilder
 
 class _$EncryptionResultImpl extends EncryptionResultImpl {
   @override
-  final BuiltList<int> built_data;
+  final BuiltList<int>? built_data;
   @override
-  final BuiltList<int> built_initializationVector;
+  final BuiltList<int>? built_initializationVector;
   @override
-  final BuiltList<int> built_authenticationTag;
+  final BuiltList<int>? built_authenticationTag;
   @override
-  final BuiltList<int> built_additionalAuthenticatedData;
-  Uint8List __data;
-  Uint8List __initializationVector;
-  Uint8List __authenticationTag;
-  Uint8List __additionalAuthenticatedData;
+  final BuiltList<int>? built_additionalAuthenticatedData;
+  Uint8List? __data;
+  Uint8List? __initializationVector;
+  Uint8List? __authenticationTag;
+  Uint8List? __additionalAuthenticatedData;
 
   factory _$EncryptionResultImpl(
-          [void Function(EncryptionResultImplBuilder b) updates]) =>
+          [void Function(EncryptionResultImplBuilder b)? updates]) =>
       (EncryptionResultImplBuilder()..update(updates)).build();
 
   _$EncryptionResultImpl._(
@@ -670,15 +670,15 @@ class _$EncryptionResultImpl extends EncryptionResultImpl {
   Uint8List get data => __data ??= super.data;
 
   @override
-  Uint8List get initializationVector =>
+  Uint8List? get initializationVector =>
       __initializationVector ??= super.initializationVector;
 
   @override
-  Uint8List get authenticationTag =>
+  Uint8List? get authenticationTag =>
       __authenticationTag ??= super.authenticationTag;
 
   @override
-  Uint8List get additionalAuthenticatedData =>
+  Uint8List? get additionalAuthenticatedData =>
       __additionalAuthenticatedData ??= super.additionalAuthenticatedData;
 
   @override
@@ -725,16 +725,16 @@ class _$EncryptionResultImpl extends EncryptionResultImpl {
 
 class EncryptionResultImplBuilder
     implements Builder<EncryptionResultImpl, EncryptionResultImplBuilder> {
-  _$EncryptionResultImpl _$v;
+  _$EncryptionResultImpl? _$v;
 
-  ListBuilder<int> _built_data;
+  ListBuilder<int>? _built_data;
 
   ListBuilder<int> get built_data => _$this._built_data ??= ListBuilder<int>();
 
   set built_data(ListBuilder<int> built_data) =>
       _$this._built_data = built_data;
 
-  ListBuilder<int> _built_initializationVector;
+  ListBuilder<int>? _built_initializationVector;
 
   ListBuilder<int> get built_initializationVector =>
       _$this._built_initializationVector ??= ListBuilder<int>();
@@ -742,7 +742,7 @@ class EncryptionResultImplBuilder
   set built_initializationVector(ListBuilder<int> built_initializationVector) =>
       _$this._built_initializationVector = built_initializationVector;
 
-  ListBuilder<int> _built_authenticationTag;
+  ListBuilder<int>? _built_authenticationTag;
 
   ListBuilder<int> get built_authenticationTag =>
       _$this._built_authenticationTag ??= ListBuilder<int>();
@@ -750,7 +750,7 @@ class EncryptionResultImplBuilder
   set built_authenticationTag(ListBuilder<int> built_authenticationTag) =>
       _$this._built_authenticationTag = built_authenticationTag;
 
-  ListBuilder<int> _built_additionalAuthenticatedData;
+  ListBuilder<int>? _built_additionalAuthenticatedData;
 
   ListBuilder<int> get built_additionalAuthenticatedData =>
       _$this._built_additionalAuthenticatedData ??= ListBuilder<int>();
@@ -764,11 +764,11 @@ class EncryptionResultImplBuilder
 
   EncryptionResultImplBuilder get _$this {
     if (_$v != null) {
-      _built_data = _$v.built_data?.toBuilder();
-      _built_initializationVector = _$v.built_initializationVector?.toBuilder();
-      _built_authenticationTag = _$v.built_authenticationTag?.toBuilder();
+      _built_data = _$v!.built_data?.toBuilder();
+      _built_initializationVector = _$v!.built_initializationVector?.toBuilder();
+      _built_authenticationTag = _$v!.built_authenticationTag?.toBuilder();
       _built_additionalAuthenticatedData =
-          _$v.built_additionalAuthenticatedData?.toBuilder();
+          _$v!.built_additionalAuthenticatedData?.toBuilder();
       _$v = null;
     }
     return this;
@@ -781,7 +781,7 @@ class EncryptionResultImplBuilder
   }
 
   @override
-  void update(void Function(EncryptionResultImplBuilder b) updates) {
+  void update(void Function(EncryptionResultImplBuilder b)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -797,7 +797,7 @@ class EncryptionResultImplBuilder
               built_additionalAuthenticatedData:
                   _built_additionalAuthenticatedData?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'built_data';
         built_data.build();

--- a/lib/src/keys.dart
+++ b/lib/src/keys.dart
@@ -5,7 +5,7 @@ abstract class Key {
   /// Creates an [Encrypter] using this key and the specified algorithm
   Encrypter createEncrypter(Identifier algorithm) {
     if (this is SymmetricKey) {
-      return _SymmetricEncrypter(algorithm, this as SymmetricKey);
+      return _SymmetricEncrypter(algorithm, this);
     }
 
     return _AsymmetricEncrypter(algorithm, this);
@@ -15,37 +15,37 @@ abstract class Key {
 /// A cryptographic public key
 abstract class PublicKey implements Key {
   /// Creates a signature [Verifier] using this key and the specified algorithm
-  Verifier createVerifier(Identifier? algorithm) {
+  Verifier createVerifier(Identifier algorithm) {
     if (this is SymmetricKey) {
-      return _SymmetricSignerAndVerifier(algorithm!, this as SymmetricKey);
+      return _SymmetricSignerAndVerifier(algorithm, this);
     }
 
-    return _AsymmetricVerifier(algorithm!, this);
+    return _AsymmetricVerifier(algorithm, this);
   }
 }
 
 /// A cryptographic private key
 abstract class PrivateKey implements Key {
   /// Creates a [Signer] using this key and the specified algorithm.
-  Signer createSigner(Identifier? algorithm) {
+  Signer createSigner(Identifier algorithm) {
     if (this is SymmetricKey) {
-      return _SymmetricSignerAndVerifier(algorithm!, this as SymmetricKey);
+      return _SymmetricSignerAndVerifier(algorithm, this);
     }
 
-    return _AsymmetricSigner(algorithm!, this);
+    return _AsymmetricSigner(algorithm, this);
   }
 }
 
 /// Holds a key pair (private and public key)
 class KeyPair {
   /// The public key
-  final PublicKey? publicKey;
+  final PublicKey publicKey;
 
   /// The private key
-  final PrivateKey? privateKey;
+  final PrivateKey privateKey;
 
   /// Creates a [KeyPair] from a public and private key
-  KeyPair({required this.publicKey, required this.privateKey});
+  KeyPair({@required this.publicKey, @required this.privateKey});
 
   /// Creates a [KeyPair] from a symmetric key
   KeyPair.symmetric(SymmetricKey key) : this(privateKey: key, publicKey: key);
@@ -54,7 +54,7 @@ class KeyPair {
   factory KeyPair.generateSymmetric(int bitLength) =>
       KeyPair.symmetric(SymmetricKey.generate(bitLength));
 
-  factory KeyPair.generateRsa({BigInt? exponent, int bitStrength = 2048}) {
+  factory KeyPair.generateRsa({BigInt exponent, int bitStrength = 2048}) {
     exponent ??= BigInt.from(65537);
 
     var generator = pc.RSAKeyGenerator()
@@ -92,8 +92,8 @@ class KeyPair {
 
     return KeyPair(
         publicKey: EcPublicKey(
-            xCoordinate: (pair.publicKey as pc.ECPublicKey).Q!.x!.toBigInteger(),
-            yCoordinate: (pair.publicKey as pc.ECPublicKey).Q!.y!.toBigInteger(),
+            xCoordinate: (pair.publicKey as pc.ECPublicKey).Q.x.toBigInteger(),
+            yCoordinate: (pair.publicKey as pc.ECPublicKey).Q.y.toBigInteger(),
             curve: curve),
         privateKey: EcPrivateKey(
             eccPrivateKey: (pair.privateKey as pc.ECPrivateKey).d,
@@ -104,7 +104,7 @@ class KeyPair {
   factory KeyPair.fromJwk(Map<String, dynamic> jwk) {
     switch (jwk['kty']) {
       case 'oct':
-        var key = SymmetricKey(keyValue: _base64ToBytes(jwk['k']) as Uint8List?);
+        var key = SymmetricKey(keyValue: _base64ToBytes(jwk['k']));
         return KeyPair(publicKey: key, privateKey: key);
       case 'RSA':
         return KeyPair(
@@ -145,13 +145,13 @@ class KeyPair {
   }
 
   /// Creates a [Signer] using the private key and the specified algorithm.
-  Signer createSigner(Identifier? algorithm) =>
-      privateKey!.createSigner(algorithm);
+  Signer createSigner(Identifier algorithm) =>
+      privateKey.createSigner(algorithm);
 
   /// Creates a signature [Verifier] using the public key and the specified
   /// algorithm
-  Verifier createVerifier(Identifier? algorithm) =>
-      publicKey!.createVerifier(algorithm);
+  Verifier createVerifier(Identifier algorithm) =>
+      publicKey.createVerifier(algorithm);
 }
 
 List<int> _base64ToBytes(String encoded) {
@@ -165,11 +165,11 @@ BigInt _base64ToInt(String encoded) {
       .fold(BigInt.zero, (a, b) => a * b256 + BigInt.from(b));
 }
 
-Identifier? _parseCurve(String? name) {
+Identifier _parseCurve(String name) {
   return {
     'P-256': curves.p256,
     'P-256K': curves.p256k,
     'P-384': curves.p384,
     'P-521': curves.p521,
-  }[name!];
+  }[name];
 }

--- a/lib/src/keys.dart
+++ b/lib/src/keys.dart
@@ -5,7 +5,7 @@ abstract class Key {
   /// Creates an [Encrypter] using this key and the specified algorithm
   Encrypter createEncrypter(Identifier algorithm) {
     if (this is SymmetricKey) {
-      return _SymmetricEncrypter(algorithm, this);
+      return _SymmetricEncrypter(algorithm, this as SymmetricKey);
     }
 
     return _AsymmetricEncrypter(algorithm, this);
@@ -15,37 +15,37 @@ abstract class Key {
 /// A cryptographic public key
 abstract class PublicKey implements Key {
   /// Creates a signature [Verifier] using this key and the specified algorithm
-  Verifier createVerifier(Identifier algorithm) {
+  Verifier createVerifier(Identifier? algorithm) {
     if (this is SymmetricKey) {
-      return _SymmetricSignerAndVerifier(algorithm, this);
+      return _SymmetricSignerAndVerifier(algorithm!, this as SymmetricKey);
     }
 
-    return _AsymmetricVerifier(algorithm, this);
+    return _AsymmetricVerifier(algorithm!, this);
   }
 }
 
 /// A cryptographic private key
 abstract class PrivateKey implements Key {
   /// Creates a [Signer] using this key and the specified algorithm.
-  Signer createSigner(Identifier algorithm) {
+  Signer createSigner(Identifier? algorithm) {
     if (this is SymmetricKey) {
-      return _SymmetricSignerAndVerifier(algorithm, this);
+      return _SymmetricSignerAndVerifier(algorithm!, this as SymmetricKey);
     }
 
-    return _AsymmetricSigner(algorithm, this);
+    return _AsymmetricSigner(algorithm!, this);
   }
 }
 
 /// Holds a key pair (private and public key)
 class KeyPair {
   /// The public key
-  final PublicKey publicKey;
+  final PublicKey? publicKey;
 
   /// The private key
-  final PrivateKey privateKey;
+  final PrivateKey? privateKey;
 
   /// Creates a [KeyPair] from a public and private key
-  KeyPair({@required this.publicKey, @required this.privateKey});
+  KeyPair({required this.publicKey, required this.privateKey});
 
   /// Creates a [KeyPair] from a symmetric key
   KeyPair.symmetric(SymmetricKey key) : this(privateKey: key, publicKey: key);
@@ -54,7 +54,7 @@ class KeyPair {
   factory KeyPair.generateSymmetric(int bitLength) =>
       KeyPair.symmetric(SymmetricKey.generate(bitLength));
 
-  factory KeyPair.generateRsa({BigInt exponent, int bitStrength = 2048}) {
+  factory KeyPair.generateRsa({BigInt? exponent, int bitStrength = 2048}) {
     exponent ??= BigInt.from(65537);
 
     var generator = pc.RSAKeyGenerator()
@@ -92,8 +92,8 @@ class KeyPair {
 
     return KeyPair(
         publicKey: EcPublicKey(
-            xCoordinate: (pair.publicKey as pc.ECPublicKey).Q.x.toBigInteger(),
-            yCoordinate: (pair.publicKey as pc.ECPublicKey).Q.y.toBigInteger(),
+            xCoordinate: (pair.publicKey as pc.ECPublicKey).Q!.x!.toBigInteger(),
+            yCoordinate: (pair.publicKey as pc.ECPublicKey).Q!.y!.toBigInteger(),
             curve: curve),
         privateKey: EcPrivateKey(
             eccPrivateKey: (pair.privateKey as pc.ECPrivateKey).d,
@@ -104,7 +104,7 @@ class KeyPair {
   factory KeyPair.fromJwk(Map<String, dynamic> jwk) {
     switch (jwk['kty']) {
       case 'oct':
-        var key = SymmetricKey(keyValue: _base64ToBytes(jwk['k']));
+        var key = SymmetricKey(keyValue: _base64ToBytes(jwk['k']) as Uint8List?);
         return KeyPair(publicKey: key, privateKey: key);
       case 'RSA':
         return KeyPair(
@@ -145,13 +145,13 @@ class KeyPair {
   }
 
   /// Creates a [Signer] using the private key and the specified algorithm.
-  Signer createSigner(Identifier algorithm) =>
-      privateKey.createSigner(algorithm);
+  Signer createSigner(Identifier? algorithm) =>
+      privateKey!.createSigner(algorithm);
 
   /// Creates a signature [Verifier] using the public key and the specified
   /// algorithm
-  Verifier createVerifier(Identifier algorithm) =>
-      publicKey.createVerifier(algorithm);
+  Verifier createVerifier(Identifier? algorithm) =>
+      publicKey!.createVerifier(algorithm);
 }
 
 List<int> _base64ToBytes(String encoded) {
@@ -165,11 +165,11 @@ BigInt _base64ToInt(String encoded) {
       .fold(BigInt.zero, (a, b) => a * b256 + BigInt.from(b));
 }
 
-Identifier _parseCurve(String name) {
+Identifier? _parseCurve(String? name) {
   return {
     'P-256': curves.p256,
     'P-256K': curves.p256k,
     'P-384': curves.p384,
     'P-521': curves.p521,
-  }[name];
+  }[name!];
 }

--- a/lib/src/keys.dart
+++ b/lib/src/keys.dart
@@ -66,12 +66,13 @@ class KeyPair {
 
     return KeyPair(
         publicKey: RsaPublicKey(
-          exponent: (pair.publicKey as pc.RSAPublicKey).e,
+          exponent: (pair.publicKey as pc.RSAPublicKey).publicExponent,
           modulus: (pair.publicKey as pc.RSAPublicKey).n,
         ),
         privateKey: RsaPrivateKey(
           modulus: (pair.privateKey as pc.RSAPrivateKey).n,
-          privateExponent: (pair.privateKey as pc.RSAPrivateKey).d,
+          privateExponent:
+              (pair.privateKey as pc.RSAPrivateKey).privateExponent,
           firstPrimeFactor: (pair.privateKey as pc.RSAPrivateKey).p,
           secondPrimeFactor: (pair.privateKey as pc.RSAPrivateKey).q,
         ));

--- a/lib/src/keys.dart
+++ b/lib/src/keys.dart
@@ -5,7 +5,7 @@ abstract class Key {
   /// Creates an [Encrypter] using this key and the specified algorithm
   Encrypter createEncrypter(Identifier algorithm) {
     if (this is SymmetricKey) {
-      return _SymmetricEncrypter(algorithm, this);
+      return _SymmetricEncrypter(algorithm, this as SymmetricKey);
     }
 
     return _AsymmetricEncrypter(algorithm, this);
@@ -15,37 +15,37 @@ abstract class Key {
 /// A cryptographic public key
 abstract class PublicKey implements Key {
   /// Creates a signature [Verifier] using this key and the specified algorithm
-  Verifier createVerifier(Identifier algorithm) {
+  Verifier createVerifier(Identifier? algorithm) {
     if (this is SymmetricKey) {
-      return _SymmetricSignerAndVerifier(algorithm, this);
+      return _SymmetricSignerAndVerifier(algorithm!, this as SymmetricKey);
     }
 
-    return _AsymmetricVerifier(algorithm, this);
+    return _AsymmetricVerifier(algorithm!, this);
   }
 }
 
 /// A cryptographic private key
 abstract class PrivateKey implements Key {
   /// Creates a [Signer] using this key and the specified algorithm.
-  Signer createSigner(Identifier algorithm) {
+  Signer createSigner(Identifier? algorithm) {
     if (this is SymmetricKey) {
-      return _SymmetricSignerAndVerifier(algorithm, this);
+      return _SymmetricSignerAndVerifier(algorithm!, this as SymmetricKey);
     }
 
-    return _AsymmetricSigner(algorithm, this);
+    return _AsymmetricSigner(algorithm!, this);
   }
 }
 
 /// Holds a key pair (private and public key)
 class KeyPair {
   /// The public key
-  final PublicKey publicKey;
+  final PublicKey? publicKey;
 
   /// The private key
-  final PrivateKey privateKey;
+  final PrivateKey? privateKey;
 
   /// Creates a [KeyPair] from a public and private key
-  KeyPair({@required this.publicKey, @required this.privateKey});
+  KeyPair({required this.publicKey, required this.privateKey});
 
   /// Creates a [KeyPair] from a symmetric key
   KeyPair.symmetric(SymmetricKey key) : this(privateKey: key, publicKey: key);
@@ -54,7 +54,7 @@ class KeyPair {
   factory KeyPair.generateSymmetric(int bitLength) =>
       KeyPair.symmetric(SymmetricKey.generate(bitLength));
 
-  factory KeyPair.generateRsa({BigInt exponent, int bitStrength = 2048}) {
+  factory KeyPair.generateRsa({BigInt? exponent, int bitStrength = 2048}) {
     exponent ??= BigInt.from(65537);
 
     var generator = pc.RSAKeyGenerator()
@@ -93,8 +93,8 @@ class KeyPair {
 
     return KeyPair(
         publicKey: EcPublicKey(
-            xCoordinate: (pair.publicKey as pc.ECPublicKey).Q.x.toBigInteger(),
-            yCoordinate: (pair.publicKey as pc.ECPublicKey).Q.y.toBigInteger(),
+            xCoordinate: (pair.publicKey as pc.ECPublicKey).Q!.x!.toBigInteger(),
+            yCoordinate: (pair.publicKey as pc.ECPublicKey).Q!.y!.toBigInteger(),
             curve: curve),
         privateKey: EcPrivateKey(
             eccPrivateKey: (pair.privateKey as pc.ECPrivateKey).d,
@@ -105,7 +105,7 @@ class KeyPair {
   factory KeyPair.fromJwk(Map<String, dynamic> jwk) {
     switch (jwk['kty']) {
       case 'oct':
-        var key = SymmetricKey(keyValue: _base64ToBytes(jwk['k']));
+        var key = SymmetricKey(keyValue: _base64ToBytes(jwk['k']) as Uint8List?);
         return KeyPair(publicKey: key, privateKey: key);
       case 'RSA':
         return KeyPair(
@@ -146,13 +146,13 @@ class KeyPair {
   }
 
   /// Creates a [Signer] using the private key and the specified algorithm.
-  Signer createSigner(Identifier algorithm) =>
-      privateKey.createSigner(algorithm);
+  Signer createSigner(Identifier? algorithm) =>
+      privateKey!.createSigner(algorithm);
 
   /// Creates a signature [Verifier] using the public key and the specified
   /// algorithm
-  Verifier createVerifier(Identifier algorithm) =>
-      publicKey.createVerifier(algorithm);
+  Verifier createVerifier(Identifier? algorithm) =>
+      publicKey!.createVerifier(algorithm);
 }
 
 List<int> _base64ToBytes(String encoded) {
@@ -166,11 +166,11 @@ BigInt _base64ToInt(String encoded) {
       .fold(BigInt.zero, (a, b) => a * b256 + BigInt.from(b));
 }
 
-Identifier _parseCurve(String name) {
+Identifier? _parseCurve(String? name) {
   return {
     'P-256': curves.p256,
     'P-256K': curves.p256k,
     'P-384': curves.p384,
     'P-521': curves.p521,
-  }[name];
+  }[name!];
 }

--- a/lib/src/operator.dart
+++ b/lib/src/operator.dart
@@ -16,7 +16,8 @@ abstract class Operator<T extends Key> {
 
 /// Operator for signing
 abstract class Signer<T extends PrivateKey> extends Operator<T> {
-  Signer._(Identifier algorithm, T key) : super._(algorithm, key);
+  Signer._(Identifier algorithm, T key)
+      : super._(algorithm as AlgorithmIdentifier<pc.Algorithm>, key);
 
   /// Signs the input [data] using the [key] and [algorithm]
   Signature sign(List<int> data);
@@ -24,7 +25,8 @@ abstract class Signer<T extends PrivateKey> extends Operator<T> {
 
 /// Operator for verifying a signature
 abstract class Verifier<T extends PublicKey> extends Operator<T> {
-  Verifier._(Identifier algorithm, T key) : super._(algorithm, key);
+  Verifier._(Identifier algorithm, T key)
+      : super._(algorithm as AlgorithmIdentifier<pc.Algorithm>, key);
 
   /// Verifies that [signature] is a valid signature for the input [data] using
   /// the [key] and [algorithm]
@@ -41,14 +43,16 @@ abstract class Signature {
 
 /// Operator for encrypting and decrypting data
 abstract class Encrypter<T extends Key> extends Operator<T> {
-  Encrypter._(Identifier algorithm, T key) : super._(algorithm, key);
+  Encrypter._(Identifier algorithm, T key)
+      : super._(algorithm as AlgorithmIdentifier<pc.Algorithm>, key);
 
   /// Encrypts the input data using the [key] and [algorithm]
   ///
   /// When the algorithm requires an initialization vector and none is provided,
   /// a random initialization vector is generated.
   EncryptionResult encrypt(Uint8List input,
-      {Uint8List initializationVector, Uint8List additionalAuthenticatedData});
+      {Uint8List? initializationVector,
+      Uint8List? additionalAuthenticatedData});
 
   /// Decrypts the input data using the [key] and [algorithm]
   Uint8List decrypt(EncryptionResult input);
@@ -61,14 +65,14 @@ abstract class EncryptionResult {
 
   /// The initialization vector used for encrypting when required by the
   /// algorithm
-  Uint8List get initializationVector;
+  Uint8List? get initializationVector;
 
-  Uint8List get authenticationTag;
+  Uint8List? get authenticationTag;
 
-  Uint8List get additionalAuthenticatedData;
+  Uint8List? get additionalAuthenticatedData;
 
   factory EncryptionResult(Uint8List data,
-      {Uint8List initializationVector,
-      Uint8List authenticationTag,
-      Uint8List additionalAuthenticatedData}) = EncryptionResultImpl;
+      {Uint8List? initializationVector,
+      Uint8List? authenticationTag,
+      Uint8List? additionalAuthenticatedData}) = EncryptionResultImpl;
 }

--- a/lib/src/operator.dart
+++ b/lib/src/operator.dart
@@ -6,7 +6,7 @@ abstract class Operator<T extends Key> {
   final T key;
 
   /// The algorithm used for this operation
-  final AlgorithmIdentifier<pc.Algorithm> algorithm;
+  final AlgorithmIdentifier algorithm;
 
   final pc.Algorithm _algorithm;
 
@@ -16,8 +16,7 @@ abstract class Operator<T extends Key> {
 
 /// Operator for signing
 abstract class Signer<T extends PrivateKey> extends Operator<T> {
-  Signer._(Identifier algorithm, T key)
-      : super._(algorithm as AlgorithmIdentifier<pc.Algorithm>, key);
+  Signer._(Identifier algorithm, T key) : super._(algorithm, key);
 
   /// Signs the input [data] using the [key] and [algorithm]
   Signature sign(List<int> data);
@@ -25,8 +24,7 @@ abstract class Signer<T extends PrivateKey> extends Operator<T> {
 
 /// Operator for verifying a signature
 abstract class Verifier<T extends PublicKey> extends Operator<T> {
-  Verifier._(Identifier algorithm, T key)
-      : super._(algorithm as AlgorithmIdentifier<pc.Algorithm>, key);
+  Verifier._(Identifier algorithm, T key) : super._(algorithm, key);
 
   /// Verifies that [signature] is a valid signature for the input [data] using
   /// the [key] and [algorithm]
@@ -43,16 +41,14 @@ abstract class Signature {
 
 /// Operator for encrypting and decrypting data
 abstract class Encrypter<T extends Key> extends Operator<T> {
-  Encrypter._(Identifier algorithm, T key)
-      : super._(algorithm as AlgorithmIdentifier<pc.Algorithm>, key);
+  Encrypter._(Identifier algorithm, T key) : super._(algorithm, key);
 
   /// Encrypts the input data using the [key] and [algorithm]
   ///
   /// When the algorithm requires an initialization vector and none is provided,
   /// a random initialization vector is generated.
   EncryptionResult encrypt(Uint8List input,
-      {Uint8List? initializationVector,
-      Uint8List? additionalAuthenticatedData});
+      {Uint8List initializationVector, Uint8List additionalAuthenticatedData});
 
   /// Decrypts the input data using the [key] and [algorithm]
   Uint8List decrypt(EncryptionResult input);
@@ -65,14 +61,14 @@ abstract class EncryptionResult {
 
   /// The initialization vector used for encrypting when required by the
   /// algorithm
-  Uint8List? get initializationVector;
+  Uint8List get initializationVector;
 
-  Uint8List? get authenticationTag;
+  Uint8List get authenticationTag;
 
-  Uint8List? get additionalAuthenticatedData;
+  Uint8List get additionalAuthenticatedData;
 
   factory EncryptionResult(Uint8List data,
-      {Uint8List? initializationVector,
-      Uint8List? authenticationTag,
-      Uint8List? additionalAuthenticatedData}) = EncryptionResultImpl;
+      {Uint8List initializationVector,
+      Uint8List authenticationTag,
+      Uint8List additionalAuthenticatedData}) = EncryptionResultImpl;
 }

--- a/lib/src/operator.dart
+++ b/lib/src/operator.dart
@@ -6,7 +6,7 @@ abstract class Operator<T extends Key> {
   final T key;
 
   /// The algorithm used for this operation
-  final AlgorithmIdentifier algorithm;
+  final AlgorithmIdentifier<pc.Algorithm> algorithm;
 
   final pc.Algorithm _algorithm;
 
@@ -16,7 +16,8 @@ abstract class Operator<T extends Key> {
 
 /// Operator for signing
 abstract class Signer<T extends PrivateKey> extends Operator<T> {
-  Signer._(Identifier algorithm, T key) : super._(algorithm, key);
+  Signer._(Identifier algorithm, T key)
+      : super._(algorithm as AlgorithmIdentifier<pc.Algorithm>, key);
 
   /// Signs the input [data] using the [key] and [algorithm]
   Signature sign(List<int> data);
@@ -24,7 +25,8 @@ abstract class Signer<T extends PrivateKey> extends Operator<T> {
 
 /// Operator for verifying a signature
 abstract class Verifier<T extends PublicKey> extends Operator<T> {
-  Verifier._(Identifier algorithm, T key) : super._(algorithm, key);
+  Verifier._(Identifier algorithm, T key)
+      : super._(algorithm as AlgorithmIdentifier<pc.Algorithm>, key);
 
   /// Verifies that [signature] is a valid signature for the input [data] using
   /// the [key] and [algorithm]
@@ -41,14 +43,16 @@ abstract class Signature {
 
 /// Operator for encrypting and decrypting data
 abstract class Encrypter<T extends Key> extends Operator<T> {
-  Encrypter._(Identifier algorithm, T key) : super._(algorithm, key);
+  Encrypter._(Identifier algorithm, T key)
+      : super._(algorithm as AlgorithmIdentifier<pc.Algorithm>, key);
 
   /// Encrypts the input data using the [key] and [algorithm]
   ///
   /// When the algorithm requires an initialization vector and none is provided,
   /// a random initialization vector is generated.
   EncryptionResult encrypt(Uint8List input,
-      {Uint8List initializationVector, Uint8List additionalAuthenticatedData});
+      {Uint8List? initializationVector,
+      Uint8List? additionalAuthenticatedData});
 
   /// Decrypts the input data using the [key] and [algorithm]
   Uint8List decrypt(EncryptionResult input);
@@ -61,14 +65,14 @@ abstract class EncryptionResult {
 
   /// The initialization vector used for encrypting when required by the
   /// algorithm
-  Uint8List get initializationVector;
+  Uint8List? get initializationVector;
 
-  Uint8List get authenticationTag;
+  Uint8List? get authenticationTag;
 
-  Uint8List get additionalAuthenticatedData;
+  Uint8List? get additionalAuthenticatedData;
 
   factory EncryptionResult(Uint8List data,
-      {Uint8List initializationVector,
-      Uint8List authenticationTag,
-      Uint8List additionalAuthenticatedData}) = EncryptionResultImpl;
+      {Uint8List? initializationVector,
+      Uint8List? authenticationTag,
+      Uint8List? additionalAuthenticatedData}) = EncryptionResultImpl;
 }

--- a/lib/src/pointycastle_ext.dart
+++ b/lib/src/pointycastle_ext.dart
@@ -15,15 +15,15 @@ class ParametersWithIVAndAad<UnderlyingParameters extends CipherParameters>
 class GCMBlockCipher extends BlockCipherWithAuthenticationTag {
   final BlockCipher _underlyingCipher;
 
-  late Uint8List _counter;
+  Uint8List _counter;
 
-  late BigInt _e;
+  BigInt _e;
 
-  BigInt? _h;
-  late BigInt _x;
-  late BigInt _e0;
+  BigInt _h;
+  BigInt _x;
+  BigInt _e0;
 
-  late int _processedBytes;
+  int _processedBytes;
 
   GCMBlockCipher(this._underlyingCipher);
 
@@ -74,7 +74,7 @@ class GCMBlockCipher extends BlockCipherWithAuthenticationTag {
     _processedBytes = 0;
 
     _h = _computeE(Uint8List(16));
-    _counter = _computeInitialCounter(_iv!);
+    _counter = _computeInitialCounter(_iv);
     _e0 = _computeE(_counter);
     _x = BigInt.zero;
 
@@ -83,16 +83,16 @@ class GCMBlockCipher extends BlockCipherWithAuthenticationTag {
 
   void _processAad() {
     var block = Uint8List(16);
-    for (var i = 0; i < _aad!.length; i += 16) {
-      block.setAll(0, _aad!.sublist(i, min(i + 16, _aad!.length)));
-      block.fillRange(min(i + 16, _aad!.length) - i, 16, 0);
+    for (var i = 0; i < _aad.length; i += 16) {
+      block.setAll(0, _aad.sublist(i, min(i + 16, _aad.length)));
+      block.fillRange(min(i + 16, _aad.length) - i, 16, 0);
       var a = _toBigInt(block);
       _x = _mult(_x ^ a, _h);
     }
   }
 
   @override
-  void initParameters(CipherParameters? params) {
+  void initParameters(CipherParameters params) {
     _underlyingCipher.reset();
     _underlyingCipher.init(true, params);
 
@@ -120,12 +120,12 @@ class GCMBlockCipher extends BlockCipherWithAuthenticationTag {
     }
   }
 
-  BigInt _mult(BigInt x, BigInt? y) {
+  BigInt _mult(BigInt x, BigInt y) {
     var v = x;
     var z = BigInt.zero;
 
     for (var i = 0; i < 128; i++) {
-      if ((y! >> (127 - i)) & BigInt.one == BigInt.one) {
+      if ((y >> (127 - i)) & BigInt.one == BigInt.one) {
         z ^= v;
       }
       if (v & BigInt.one == BigInt.zero) {
@@ -164,7 +164,7 @@ class GCMBlockCipher extends BlockCipherWithAuthenticationTag {
     _writeBigInt(
         o, Uint8List.view(out.buffer, out.offsetInBytes + outOff, length));
 
-    var c = _encrypting! ? o : i;
+    var c = _encrypting ? o : i;
     c <<= padLength;
     _x = _mult(_x ^ c, _h);
 
@@ -173,7 +173,7 @@ class GCMBlockCipher extends BlockCipherWithAuthenticationTag {
 
   @override
   Uint8List finalizeTag() {
-    var len = (BigInt.from(aad!.length) << (64 + 3)) +
+    var len = (BigInt.from(aad.length) << (64 + 3)) +
         (BigInt.from(_processedBytes) << 3);
     _x = _mult(_x ^ len, _h);
 
@@ -191,21 +191,21 @@ String toHex(Iterable<int> bytes) {
 }
 
 abstract class BlockCipherWithAuthenticationTag implements BlockCipher {
-  bool? _encrypting;
-  Uint8List? _aad;
-  Uint8List? _iv;
+  bool _encrypting;
+  Uint8List _aad;
+  Uint8List _iv;
 
-  bool? get isEncrypting => _encrypting;
+  bool get isEncrypting => _encrypting;
 
-  Uint8List? get aad => _aad;
+  Uint8List get aad => _aad;
 
-  Uint8List? get iv => _iv;
+  Uint8List get iv => _iv;
 
   int get tagLength;
 
   @override
   Uint8List process(Uint8List data) {
-    if (isEncrypting!) {
+    if (isEncrypting) {
       var ciphertext = processBlocks(data);
       var tag = finalizeTag();
       var out = Uint8List(ciphertext.length + tag.length);
@@ -243,7 +243,7 @@ abstract class BlockCipherWithAuthenticationTag implements BlockCipher {
 
   Uint8List finalizeTag();
 
-  void initParameters(CipherParameters? parameters);
+  void initParameters(CipherParameters parameters);
 
   @override
   void init(bool forEncryption, covariant ParametersWithIVAndAad params) {
@@ -288,11 +288,11 @@ class AesCbcAuthenticatedCipherWithHash
 
     _underlyingMac.init(KeyParameter(macKey));
     _underlyingCipher.init(
-        isEncrypting!,
+        isEncrypting,
         PaddedBlockCipherParameters(
             ParametersWithIV(
               KeyParameter(encKey),
-              iv!,
+              iv,
             ),
             null));
   }
@@ -307,20 +307,20 @@ class AesCbcAuthenticatedCipherWithHash
     throw UnsupportedError('Should not be called');
   }
 
-  late Uint8List _hash;
+  Uint8List _hash;
 
   @override
   Uint8List processBlocks(Uint8List data) {
     var out = _underlyingCipher.process(data);
 
-    var ciphertext = isEncrypting! ? out : data;
+    var ciphertext = isEncrypting ? out : data;
 
-    var hashInput = Uint8List(aad!.length + iv!.length + ciphertext.length + 8);
+    var hashInput = Uint8List(aad.length + iv.length + ciphertext.length + 8);
 
-    var al = aad!.length * 8;
-    hashInput.setAll(0, aad!);
-    hashInput.setAll(aad!.length, iv!);
-    hashInput.setAll(aad!.length + iv!.length, ciphertext);
+    var al = aad.length * 8;
+    hashInput.setAll(0, aad);
+    hashInput.setAll(aad.length, iv);
+    hashInput.setAll(aad.length + iv.length, ciphertext);
     for (var i = hashInput.length - 1; i > (hashInput.length - 8); i--) {
       hashInput[i] = al % 256;
       al >>= 8;
@@ -358,10 +358,10 @@ class AESKeyWrap implements BlockCipher {
     0xa6,
     0xa6,
   ]);
-  late bool _encrypting;
+  bool _encrypting;
 
   @override
-  void init(bool forEncryption, covariant KeyParameter? params) {
+  void init(bool forEncryption, covariant KeyParameter params) {
     _encrypting = forEncryption;
     _underlyingCipher.init(forEncryption, params);
   }

--- a/lib/src/pointycastle_oaep256.dart
+++ b/lib/src/pointycastle_oaep256.dart
@@ -14,17 +14,17 @@ class OAEP256Encoding extends BaseAsymmetricBlockCipher {
       AsymmetricBlockCipher,
       '/OAEP-256',
       (_, final Match match) => () {
-            var underlyingCipher = AsymmetricBlockCipher(match.group(1));
+            var underlyingCipher = AsymmetricBlockCipher(match.group(1)!);
             return OAEP256Encoding(underlyingCipher);
           });
 
   Digest hash = SHA256Digest();
-  Digest mgf1Hash;
+  late Digest mgf1Hash;
   Uint8List defHash = Uint8List(SHA256Digest().digestSize);
 
   final AsymmetricBlockCipher _engine;
-  SecureRandom _random;
-  bool _forEncryption;
+  late SecureRandom _random;
+  late bool _forEncryption;
 
   OAEP256Encoding(this._engine) {
     SHA256Digest().doFinal(defHash, 0);
@@ -60,11 +60,11 @@ class OAEP256Encoding extends BaseAsymmetricBlockCipher {
     if (params is ParametersWithRandom) {
       var paramswr = params;
       _random = paramswr.random;
-      akparams = paramswr.parameters;
+      akparams = paramswr.parameters as AsymmetricKeyParameter<AsymmetricKey>;
     } else {
       _random = FortunaRandom();
       _random.seed(KeyParameter(_seed()));
-      akparams = params;
+      akparams = params as AsymmetricKeyParameter<AsymmetricKey>;
     }
     _engine.init(forEncryption, akparams);
     _forEncryption = forEncryption;

--- a/lib/src/pointycastle_oaep256.dart
+++ b/lib/src/pointycastle_oaep256.dart
@@ -14,17 +14,17 @@ class OAEP256Encoding extends BaseAsymmetricBlockCipher {
       AsymmetricBlockCipher,
       '/OAEP-256',
       (_, final Match match) => () {
-            var underlyingCipher = AsymmetricBlockCipher(match.group(1)!);
+            var underlyingCipher = AsymmetricBlockCipher(match.group(1));
             return OAEP256Encoding(underlyingCipher);
           });
 
   Digest hash = SHA256Digest();
-  late Digest mgf1Hash;
+  Digest mgf1Hash;
   Uint8List defHash = Uint8List(SHA256Digest().digestSize);
 
   final AsymmetricBlockCipher _engine;
-  late SecureRandom _random;
-  late bool _forEncryption;
+  SecureRandom _random;
+  bool _forEncryption;
 
   OAEP256Encoding(this._engine) {
     SHA256Digest().doFinal(defHash, 0);
@@ -60,11 +60,11 @@ class OAEP256Encoding extends BaseAsymmetricBlockCipher {
     if (params is ParametersWithRandom) {
       var paramswr = params;
       _random = paramswr.random;
-      akparams = paramswr.parameters as AsymmetricKeyParameter<AsymmetricKey>;
+      akparams = paramswr.parameters;
     } else {
       _random = FortunaRandom();
       _random.seed(KeyParameter(_seed()));
-      akparams = params as AsymmetricKeyParameter<AsymmetricKey>;
+      akparams = params;
     }
     _engine.init(forEncryption, akparams);
     _forEncryption = forEncryption;

--- a/lib/src/rsa_keys.dart
+++ b/lib/src/rsa_keys.dart
@@ -3,32 +3,32 @@ part of '../crypto_keys.dart';
 /// Base class for RSA keys
 abstract class RsaKey extends Key {
   /// The modulus value for the RSA key
-  BigInt? get modulus;
+  BigInt get modulus;
 }
 
 /// A RSA public key
 abstract class RsaPublicKey extends RsaKey implements PublicKey {
   /// The exponent value for the RSA public key
-  BigInt? get exponent;
+  BigInt get exponent;
 
-  factory RsaPublicKey({required BigInt? modulus, required BigInt? exponent}) =
+  factory RsaPublicKey({@required BigInt modulus, @required BigInt exponent}) =
       RsaPublicKeyImpl;
 }
 
 /// A RSA private key
 abstract class RsaPrivateKey extends RsaKey implements PrivateKey {
   /// The private exponent value for the RSA private key
-  BigInt? get privateExponent;
+  BigInt get privateExponent;
 
   /// The first prime factor
-  BigInt? get firstPrimeFactor;
+  BigInt get firstPrimeFactor;
 
   /// The second prime factor
-  BigInt? get secondPrimeFactor;
+  BigInt get secondPrimeFactor;
 
   factory RsaPrivateKey(
-      {required BigInt? privateExponent,
-      required BigInt? firstPrimeFactor,
-      required BigInt? secondPrimeFactor,
-      required BigInt? modulus}) = RsaPrivateKeyImpl;
+      {@required BigInt privateExponent,
+      @required BigInt firstPrimeFactor,
+      @required BigInt secondPrimeFactor,
+      @required BigInt modulus}) = RsaPrivateKeyImpl;
 }

--- a/lib/src/rsa_keys.dart
+++ b/lib/src/rsa_keys.dart
@@ -3,32 +3,32 @@ part of '../crypto_keys.dart';
 /// Base class for RSA keys
 abstract class RsaKey extends Key {
   /// The modulus value for the RSA key
-  BigInt get modulus;
+  BigInt? get modulus;
 }
 
 /// A RSA public key
 abstract class RsaPublicKey extends RsaKey implements PublicKey {
   /// The exponent value for the RSA public key
-  BigInt get exponent;
+  BigInt? get exponent;
 
-  factory RsaPublicKey({@required BigInt modulus, @required BigInt exponent}) =
+  factory RsaPublicKey({required BigInt? modulus, required BigInt? exponent}) =
       RsaPublicKeyImpl;
 }
 
 /// A RSA private key
 abstract class RsaPrivateKey extends RsaKey implements PrivateKey {
   /// The private exponent value for the RSA private key
-  BigInt get privateExponent;
+  BigInt? get privateExponent;
 
   /// The first prime factor
-  BigInt get firstPrimeFactor;
+  BigInt? get firstPrimeFactor;
 
   /// The second prime factor
-  BigInt get secondPrimeFactor;
+  BigInt? get secondPrimeFactor;
 
   factory RsaPrivateKey(
-      {@required BigInt privateExponent,
-      @required BigInt firstPrimeFactor,
-      @required BigInt secondPrimeFactor,
-      @required BigInt modulus}) = RsaPrivateKeyImpl;
+      {required BigInt? privateExponent,
+      required BigInt? firstPrimeFactor,
+      required BigInt? secondPrimeFactor,
+      required BigInt? modulus}) = RsaPrivateKeyImpl;
 }

--- a/lib/src/symmetric_keys.dart
+++ b/lib/src/symmetric_keys.dart
@@ -3,9 +3,9 @@ part of '../crypto_keys.dart';
 /// A symmetric key
 abstract class SymmetricKey extends Key with PublicKey, PrivateKey {
   /// The value of the symmetric (or other single-valued) key
-  Uint8List? get keyValue;
+  Uint8List get keyValue;
 
-  factory SymmetricKey({Uint8List? keyValue}) = SymmetricKeyImpl;
+  factory SymmetricKey({Uint8List keyValue}) = SymmetricKeyImpl;
 
   factory SymmetricKey.generate(int bitLength) {
     if (bitLength % 8 != 0) {

--- a/lib/src/symmetric_keys.dart
+++ b/lib/src/symmetric_keys.dart
@@ -3,9 +3,9 @@ part of '../crypto_keys.dart';
 /// A symmetric key
 abstract class SymmetricKey extends Key with PublicKey, PrivateKey {
   /// The value of the symmetric (or other single-valued) key
-  Uint8List get keyValue;
+  Uint8List? get keyValue;
 
-  factory SymmetricKey({Uint8List keyValue}) = SymmetricKeyImpl;
+  factory SymmetricKey({Uint8List? keyValue}) = SymmetricKeyImpl;
 
   factory SymmetricKey.generate(int bitLength) {
     if (bitLength % 8 != 0) {

--- a/lib/src/symmetric_operator.dart
+++ b/lib/src/symmetric_operator.dart
@@ -6,12 +6,12 @@ class _SymmetricSignerAndVerifier extends Signer<SymmetricKey>
       : super._(algorithm, key);
 
   @override
-  pc.Mac get _algorithm => super._algorithm as pc.Mac;
+  pc.Mac get _algorithm => super._algorithm;
 
   @override
   Signature sign(List<int> data) {
     data = data is Uint8List ? data : Uint8List.fromList(data);
-    _algorithm.init(pc.KeyParameter(key.keyValue!));
+    _algorithm.init(pc.KeyParameter(key.keyValue));
     return Signature(_algorithm.process(data));
   }
 
@@ -24,16 +24,16 @@ class _SymmetricEncrypter extends Encrypter<SymmetricKey> {
       : super._(algorithm, key);
 
   @override
-  pc.BlockCipher get _algorithm => super._algorithm as pc.BlockCipher;
+  pc.BlockCipher get _algorithm => super._algorithm;
 
   pc.CipherParameters _getParams(
-      Uint8List? initializationVector, Uint8List? additionalAuthenticatedData) {
-    var keyParam = pc.KeyParameter(key.keyValue!);
+      Uint8List initializationVector, Uint8List additionalAuthenticatedData) {
+    var keyParam = pc.KeyParameter(key.keyValue);
 
     if (_algorithm is pc.AESKeyWrap) return keyParam;
 
-    var paramsWithIV = pc.ParametersWithIVAndAad(keyParam,
-        initializationVector!, additionalAuthenticatedData ?? Uint8List(0));
+    var paramsWithIV = pc.ParametersWithIVAndAad(keyParam, initializationVector,
+        additionalAuthenticatedData ?? Uint8List(0));
 
     if (_algorithm is pc.PaddedBlockCipher) {
       return pc.PaddedBlockCipherParameters(paramsWithIV, null);
@@ -50,17 +50,16 @@ class _SymmetricEncrypter extends Encrypter<SymmetricKey> {
             input.initializationVector, input.additionalAuthenticatedData));
     var data = input.data;
     if (input.authenticationTag != null) {
-      data = Uint8List(data.length + input.authenticationTag!.length);
+      data = Uint8List(data.length + input.authenticationTag.length);
       data.setAll(0, input.data);
-      data.setAll(input.data.length, input.authenticationTag!);
+      data.setAll(input.data.length, input.authenticationTag);
     }
     return _algorithm.process(data);
   }
 
   @override
   EncryptionResult encrypt(Uint8List input,
-      {Uint8List? initializationVector,
-      Uint8List? additionalAuthenticatedData}) {
+      {Uint8List initializationVector, Uint8List additionalAuthenticatedData}) {
     initializationVector ??=
         DefaultSecureRandom().nextBytes(_algorithm.blockSize);
 

--- a/lib/src/symmetric_operator.dart
+++ b/lib/src/symmetric_operator.dart
@@ -6,12 +6,12 @@ class _SymmetricSignerAndVerifier extends Signer<SymmetricKey>
       : super._(algorithm, key);
 
   @override
-  pc.Mac get _algorithm => super._algorithm;
+  pc.Mac get _algorithm => super._algorithm as pc.Mac;
 
   @override
   Signature sign(List<int> data) {
     data = data is Uint8List ? data : Uint8List.fromList(data);
-    _algorithm.init(pc.KeyParameter(key.keyValue));
+    _algorithm.init(pc.KeyParameter(key.keyValue!));
     return Signature(_algorithm.process(data));
   }
 
@@ -24,16 +24,16 @@ class _SymmetricEncrypter extends Encrypter<SymmetricKey> {
       : super._(algorithm, key);
 
   @override
-  pc.BlockCipher get _algorithm => super._algorithm;
+  pc.BlockCipher get _algorithm => super._algorithm as pc.BlockCipher;
 
   pc.CipherParameters _getParams(
-      Uint8List initializationVector, Uint8List additionalAuthenticatedData) {
-    var keyParam = pc.KeyParameter(key.keyValue);
+      Uint8List? initializationVector, Uint8List? additionalAuthenticatedData) {
+    var keyParam = pc.KeyParameter(key.keyValue!);
 
     if (_algorithm is pc.AESKeyWrap) return keyParam;
 
-    var paramsWithIV = pc.ParametersWithIVAndAad(keyParam, initializationVector,
-        additionalAuthenticatedData ?? Uint8List(0));
+    var paramsWithIV = pc.ParametersWithIVAndAad(keyParam,
+        initializationVector!, additionalAuthenticatedData ?? Uint8List(0));
 
     if (_algorithm is pc.PaddedBlockCipher) {
       return pc.PaddedBlockCipherParameters(paramsWithIV, null);
@@ -50,16 +50,17 @@ class _SymmetricEncrypter extends Encrypter<SymmetricKey> {
             input.initializationVector, input.additionalAuthenticatedData));
     var data = input.data;
     if (input.authenticationTag != null) {
-      data = Uint8List(data.length + input.authenticationTag.length);
+      data = Uint8List(data.length + input.authenticationTag!.length);
       data.setAll(0, input.data);
-      data.setAll(input.data.length, input.authenticationTag);
+      data.setAll(input.data.length, input.authenticationTag!);
     }
     return _algorithm.process(data);
   }
 
   @override
   EncryptionResult encrypt(Uint8List input,
-      {Uint8List initializationVector, Uint8List additionalAuthenticatedData}) {
+      {Uint8List? initializationVector,
+      Uint8List? additionalAuthenticatedData}) {
     initializationVector ??=
         DefaultSecureRandom().nextBytes(_algorithm.blockSize);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: crypto_keys
 description: A library for doing cryptographic signing/verifying and encrypting/decrypting.
-version: 0.1.3
+version: 1.0.0
 homepage: https://github.com/appsup-dart/crypto_keys
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  pointycastle: ^1.0.0
-  meta: ^1.1.6
-  built_value: ">=6.0.0 <8.0.0"
-  built_collection: ^4.0.0
+  pointycastle: ^3.0.0-nullsafety.2
+  meta: ^1.3.0
+  built_value: ^8.0.0
+  built_collection: ^5.0.0
 
 dev_dependencies:
   test: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: crypto_keys
 description: A library for doing cryptographic signing/verifying and encrypting/decrypting.
-version: 0.1.3
+version: 1.0.0
 homepage: https://github.com/appsup-dart/crypto_keys
 
 environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  pointycastle: ^1.0.0
-  meta: ^1.1.6
-  built_value: ">=6.0.0 <8.0.0"
-  built_collection: ^4.0.0
+  pointycastle: ^3.0.0-nullsafety.2
+  meta: ^1.3.0
+  built_value: ^8.0.0
+  built_collection: ^5.0.0
 
 dev_dependencies:
   test: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: crypto_keys
 description: A library for doing cryptographic signing/verifying and encrypting/decrypting.
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/appsup-dart/crypto_keys
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  pointycastle: ^1.0.0
+  pointycastle: ^2.0.0
   meta: ^1.1.6
   built_value: ">=6.0.0 <8.0.0"
   built_collection: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: crypto_keys
 description: A library for doing cryptographic signing/verifying and encrypting/decrypting.
-version: 1.0.0
+version: 0.1.3
 homepage: https://github.com/appsup-dart/crypto_keys
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  pointycastle: ^3.0.0-nullsafety.2
-  meta: ^1.3.0
-  built_value: ^8.0.0
-  built_collection: ^5.0.0
+  pointycastle: ^1.0.0
+  meta: ^1.1.6
+  built_value: ">=6.0.0 <8.0.0"
+  built_collection: ^4.0.0
 
 dev_dependencies:
   test: ^1.0.0

--- a/test/crypto_keys_test.dart
+++ b/test/crypto_keys_test.dart
@@ -4,15 +4,15 @@ import 'dart:typed_data';
 import 'dart:convert';
 
 void _testSigning(
-    KeyPair keyPair, AlgorithmIdentifier algorithm, Uint8List data,
-    [Uint8List signature, bool isRandom]) {
+    KeyPair keyPair, AlgorithmIdentifier? algorithm, Uint8List data,
+    [Uint8List? signature, bool? isRandom]) {
   var signer = keyPair.createSigner(algorithm);
   var verifier = keyPair.createVerifier(algorithm);
 
   if (signature != null) {
     expect(verifier.verify(data, Signature(signature)), isTrue);
 
-    if (!isRandom) {
+    if (!isRandom!) {
       expect(signer.sign(data).data, signature);
     }
   }
@@ -25,14 +25,14 @@ void _testSigning(
 
 void _testEncryption(
     KeyPair keyPair, AlgorithmIdentifier algorithm, Uint8List data,
-    [EncryptionResult encryptedData, bool isRandom]) {
-  var encrypter = keyPair.publicKey.createEncrypter(algorithm);
-  var decrypter = keyPair.privateKey.createEncrypter(algorithm);
+    [EncryptionResult? encryptedData, bool? isRandom]) {
+  var encrypter = keyPair.publicKey!.createEncrypter(algorithm);
+  var decrypter = keyPair.privateKey!.createEncrypter(algorithm);
 
   if (encryptedData != null) {
     expect(decrypter.decrypt(encryptedData), data);
 
-    if (!isRandom) {
+    if (!isRandom!) {
       expect(
           encrypter.encrypt(data,
               initializationVector: encryptedData.initializationVector,
@@ -682,7 +682,7 @@ void main() {
         var keyPair = KeyPair.generateRsa();
         var alg = algorithms.signing.rsa.sha384;
 
-        _testSigning(keyPair, alg, data);
+        _testSigning(keyPair, alg, data as Uint8List);
       });
     });
 
@@ -1091,7 +1091,7 @@ void main() {
             curves.p521: algorithms.signing.ecdsa.sha512,
           }[curve];
 
-          _testSigning(keyPair, alg, data);
+          _testSigning(keyPair, alg, data as Uint8List);
         }
       });
     });

--- a/test/crypto_keys_test.dart
+++ b/test/crypto_keys_test.dart
@@ -4,15 +4,15 @@ import 'dart:typed_data';
 import 'dart:convert';
 
 void _testSigning(
-    KeyPair keyPair, AlgorithmIdentifier? algorithm, Uint8List data,
-    [Uint8List? signature, bool? isRandom]) {
+    KeyPair keyPair, AlgorithmIdentifier algorithm, Uint8List data,
+    [Uint8List signature, bool isRandom]) {
   var signer = keyPair.createSigner(algorithm);
   var verifier = keyPair.createVerifier(algorithm);
 
   if (signature != null) {
     expect(verifier.verify(data, Signature(signature)), isTrue);
 
-    if (!isRandom!) {
+    if (!isRandom) {
       expect(signer.sign(data).data, signature);
     }
   }
@@ -25,14 +25,14 @@ void _testSigning(
 
 void _testEncryption(
     KeyPair keyPair, AlgorithmIdentifier algorithm, Uint8List data,
-    [EncryptionResult? encryptedData, bool? isRandom]) {
-  var encrypter = keyPair.publicKey!.createEncrypter(algorithm);
-  var decrypter = keyPair.privateKey!.createEncrypter(algorithm);
+    [EncryptionResult encryptedData, bool isRandom]) {
+  var encrypter = keyPair.publicKey.createEncrypter(algorithm);
+  var decrypter = keyPair.privateKey.createEncrypter(algorithm);
 
   if (encryptedData != null) {
     expect(decrypter.decrypt(encryptedData), data);
 
-    if (!isRandom!) {
+    if (!isRandom) {
       expect(
           encrypter.encrypt(data,
               initializationVector: encryptedData.initializationVector,
@@ -682,7 +682,7 @@ void main() {
         var keyPair = KeyPair.generateRsa();
         var alg = algorithms.signing.rsa.sha384;
 
-        _testSigning(keyPair, alg, data as Uint8List);
+        _testSigning(keyPair, alg, data);
       });
     });
 
@@ -1091,7 +1091,7 @@ void main() {
             curves.p521: algorithms.signing.ecdsa.sha512,
           }[curve];
 
-          _testSigning(keyPair, alg, data as Uint8List);
+          _testSigning(keyPair, alg, data);
         }
       });
     });

--- a/test/crypto_keys_test.dart
+++ b/test/crypto_keys_test.dart
@@ -4,15 +4,15 @@ import 'dart:typed_data';
 import 'dart:convert';
 
 void _testSigning(
-    KeyPair keyPair, AlgorithmIdentifier algorithm, Uint8List data,
-    [Uint8List signature, bool isRandom]) {
+    KeyPair keyPair, AlgorithmIdentifier? algorithm, Uint8List data,
+    [Uint8List? signature, bool? isRandom]) {
   var signer = keyPair.createSigner(algorithm);
   var verifier = keyPair.createVerifier(algorithm);
 
   if (signature != null) {
     expect(verifier.verify(data, Signature(signature)), isTrue);
 
-    if (!isRandom) {
+    if (!isRandom!) {
       expect(signer.sign(data).data, signature);
     }
   }
@@ -27,17 +27,17 @@ void _testEncryption(
   KeyPair keyPair,
   AlgorithmIdentifier algorithm,
   Uint8List data, [
-  EncryptionResult encryptedData,
-  bool isRandom,
+  EncryptionResult? encryptedData,
+  bool? isRandom,
   bool biDirectional = true,
 ]) {
-  var encrypter = keyPair.publicKey.createEncrypter(algorithm);
-  var decrypter = keyPair.privateKey.createEncrypter(algorithm);
+  var encrypter = keyPair.publicKey!.createEncrypter(algorithm);
+  var decrypter = keyPair.privateKey!.createEncrypter(algorithm);
 
   if (encryptedData != null) {
     expect(decrypter.decrypt(encryptedData), data);
 
-    if (!isRandom) {
+    if (!isRandom!) {
       expect(
           encrypter.encrypt(data,
               initializationVector: encryptedData.initializationVector,
@@ -695,7 +695,7 @@ void main() {
         var keyPair = KeyPair.generateRsa();
         var alg = algorithms.signing.rsa.sha384;
 
-        _testSigning(keyPair, alg, data);
+        _testSigning(keyPair, alg, data as Uint8List);
       });
     });
 
@@ -1104,7 +1104,7 @@ void main() {
             curves.p521: algorithms.signing.ecdsa.sha512,
           }[curve];
 
-          _testSigning(keyPair, alg, data);
+          _testSigning(keyPair, alg, data as Uint8List);
         }
       });
     });

--- a/test/crypto_keys_test.dart
+++ b/test/crypto_keys_test.dart
@@ -24,8 +24,13 @@ void _testSigning(
 }
 
 void _testEncryption(
-    KeyPair keyPair, AlgorithmIdentifier algorithm, Uint8List data,
-    [EncryptionResult encryptedData, bool isRandom]) {
+  KeyPair keyPair,
+  AlgorithmIdentifier algorithm,
+  Uint8List data, [
+  EncryptionResult encryptedData,
+  bool isRandom,
+  bool biDirectional = true,
+]) {
   var encrypter = keyPair.publicKey.createEncrypter(algorithm);
   var decrypter = keyPair.privateKey.createEncrypter(algorithm);
 
@@ -48,12 +53,20 @@ void _testEncryption(
           additionalAuthenticatedData:
               encryptedData?.additionalAuthenticatedData)),
       data);
-  expect(
-      encrypter.decrypt(decrypter.encrypt(data,
+
+  if (biDirectional == true) {
+    expect(
+      encrypter.decrypt(
+        decrypter.encrypt(
+          data,
           initializationVector: encryptedData?.initializationVector,
           additionalAuthenticatedData:
-              encryptedData?.additionalAuthenticatedData)),
-      data);
+              encryptedData?.additionalAuthenticatedData,
+        ),
+      ),
+      data,
+    );
+  }
 }
 
 void main() {
@@ -2400,8 +2413,15 @@ void main() {
           206
         ]));
 
+        /// OAEP doesn't support decryption from a PrivateKey in PointyCastle.
         _testEncryption(
-            keyPair, algorithms.encryption.rsa.oaep, data, encryptedData, true);
+          keyPair,
+          algorithms.encryption.rsa.oaep,
+          data,
+          encryptedData,
+          true,
+          false,
+        );
       });
 
       test('Example encryption using RSAES-OAEP-256', () {


### PR DESCRIPTION
Builds on https://github.com/appsup-dart/crypto_keys/pull/3 with additional migration to null safety.

There is just one test failing:
```
00:02 +8 -1: test/crypto_keys_test.dart: Signing Signing with EC keys Example Signing Using ECDSA P-256K SHA-256 [E]                                                                                       
  type 'Null' is not a subtype of type 'List<int>' of 'seed'
  dart:core                                                          _TypeError._throwNew
  package:pointycastle/src/ec_standard_curve_constructor.dart 20:21  constructFpStandardCurve
  package:pointycastle/ecc/curves/secp256k1.dart 15:34               new ECCurve_secp256k1
  package:crypto_keys/src/asymmetric_operator.dart 10:19             _AsymmetricOperator.createCurveParameters
  package:crypto_keys/src/keys.dart 86:33                            new KeyPair.generateEc
  test/crypto_keys_test.dart 903:31                                  main.<fn>.<fn>.<fn>
  
00:03 +25 -1: Some tests failed.  
```

One are I wasn't sure on is when using `ParametersWithRandom` from PC you cannot pass `null` for `random` anymore. I took a guess but this might be wrong.