### PR TITLE
0.3.1: Replaced pce.GCMBlockCipher with pc.GCMBlockCipher

### DIFF
--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -1,11 +1,13 @@
 library crypto_keys.algorithms;
 
-import 'package:crypto_keys/src/pointycastle_oaep256.dart';
-import 'package:pointycastle/export.dart' as pc hide GCMBlockCipher; // TODO
-import 'package:pointycastle/pointycastle.dart';
 import 'dart:math' show Random;
-import 'pointycastle_ext.dart' as pce;
 import 'dart:typed_data';
+
+import 'package:crypto_keys/src/pointycastle_oaep256.dart';
+import 'package:pointycastle/export.dart' as pc; // TODO
+import 'package:pointycastle/pointycastle.dart';
+
+import 'pointycastle_ext.dart' as pce;
 
 /// Contains the identifiers for supported algorithms
 ///
@@ -31,7 +33,7 @@ class Algorithms {
   final encrypting_aes_cbc = AlgorithmIdentifier._(
       'enc/AES/CBC/PKCS7',
       () => pc.PaddedBlockCipherImpl(
-          pc.PKCS7Padding(), pc.CBCBlockCipher(pc.AESFastEngine())));
+          pc.PKCS7Padding(), pc.CBCBlockCipher(pc.AESEngine())));
 
   Algorithms();
 }
@@ -103,13 +105,14 @@ class AesEncAlgorithms extends Identifier {
   final cbc = AlgorithmIdentifier._(
       'enc/AES/CBC/PKCS7',
       () => pc.PaddedBlockCipherImpl(
-          pc.PKCS7Padding(), pc.CBCBlockCipher(pc.AESFastEngine())));
+          pc.PKCS7Padding(), pc.CBCBlockCipher(pc.AESEngine())));
 
   final cbcWithHmac = AesWithHmacEncAlgorithms();
 
   /// AES GCM
+
   final gcm = AlgorithmIdentifier._(
-      'enc/AES/GCM', () => pce.GCMBlockCipher(pc.AESFastEngine()));
+      "enc/AES/GCM", () => pc.GCMBlockCipher(pc.AESEngine()));
 
   /// AES EAX
   final eax =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: crypto_keys
 description: A library for doing cryptographic signing/verifying and encrypting/decrypting.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/appsup-dart/crypto_keys
 
 environment:


### PR DESCRIPTION
As A256GCM appears to be broken in package jose, this is a version of crypto_keys that uses GCMBlockCipher of pointycastle. It fixes the issue jose4j (and cjose) has with A256GCM-encrypted content of jose package.

Still passes all tests.