### PR TITLE
Add ES256K into supported algorithm

### DIFF
--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -296,6 +296,9 @@ class AlgorithmIdentifier<T extends pc.Algorithm> extends Identifier {
     /// ECDSA using P-256 and SHA-256
     'ES256': algorithms.signing.ecdsa.sha256,
 
+    /// ECDSA using P-256 and SHA-256
+    'ES256K': algorithms.signing.ecdsa.sha256,
+
     /// ECDSA using P-384 and SHA-384
     'ES384': algorithms.signing.ecdsa.sha384,
 

--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -296,7 +296,7 @@ class AlgorithmIdentifier<T extends pc.Algorithm> extends Identifier {
     /// ECDSA using P-256 and SHA-256
     'ES256': algorithms.signing.ecdsa.sha256,
 
-    /// ECDSA using P-256 and SHA-256
+    /// ECDSA using P-256K and SHA-256
     'ES256K': algorithms.signing.ecdsa.sha256,
 
     /// ECDSA using P-384 and SHA-384


### PR DESCRIPTION
I was trying to implement JOSE/JWT using ES256K algorithm using (jose) [https://pub.dev/packages/jose](https://pub.dev/packages/jose), which listed as supported signing algo JWS on it's README. But, turns out it did not work and give me error that algo is not supported. I tried to dig out on the source code and found that the algo is not listed on the library and also in this library that listed as it's dependency.

Thank you!